### PR TITLE
Integrate legacy Prophet v2.3 CLI lineage as reference

### DIFF
--- a/docs/legacy/prophet_cli_v2_3/FILE_MANIFEST.md
+++ b/docs/legacy/prophet_cli_v2_3/FILE_MANIFEST.md
@@ -1,0 +1,44 @@
+# Legacy Prophet v2.3 file manifest
+
+The following unpublished files were reviewed and mapped into the new façade/engine design.
+
+## Reviewed files
+
+- `internal/cmd/a2a.go`
+- `internal/cmd/root.go`
+- `cmd/prophet/main.go`
+- `internal/mcp/tritrpc.go`
+- `internal/util/carrier.go`
+- `internal/util/crc16.go`
+- `README.md`
+
+## What they taught us
+
+### Keep
+- small Cobra root and entrypoint structure
+- A2A workflow phases: propose, test, review/block, revise, merge, done
+- config-driven MCP server lookup
+- machine-readable local carrier emission, even in dry-run mode
+
+### Replace
+- ephemeral signing keys generated at startup
+- transport crypto and nonce handling from the prototype
+- minimal command taxonomy (`prophet` + `a2a run` only)
+- hardcoded demo-only tool IDs and method names
+
+## New target layout
+
+The old files should inform these targets:
+
+- `cmd/prophet/main.go`
+- `internal/cmd/root.go`
+- `internal/cmd/a2a.go`
+- `internal/a2a/`
+- `internal/config/`
+- `internal/runtime/`
+- `internal/transport/`
+- `internal/receipts/`
+
+## Integration rule
+
+Legacy files are **reference lineage**, not canonical production code. Port ideas intentionally and replace trust/protocol internals with the newer frozen design.

--- a/docs/legacy/prophet_cli_v2_3/MIGRATION_MAP.md
+++ b/docs/legacy/prophet_cli_v2_3/MIGRATION_MAP.md
@@ -1,0 +1,26 @@
+# Legacy v2.3 to current layout migration map
+
+| Legacy file | Keep / replace / adapt | New target | Notes |
+|---|---|---|---|
+| `cmd/prophet/main.go` | keep shape | `cmd/prophet/main.go` | keep a small entrypoint |
+| `internal/cmd/root.go` | adapt | `internal/cmd/root.go` | expand to canonical verbs, profiles, spaces, agent overlay |
+| `internal/cmd/a2a.go` | adapt | `internal/cmd/a2a.go` + `internal/a2a/` | preserve workflow phases, remove hardcoded demo semantics |
+| `internal/mcp/tritrpc.go` | replace | `internal/config/` + `internal/transport/` | preserve header/socket/config-loading ideas; replace crypto and frame semantics |
+| `internal/util/carrier.go` | replace | `internal/receipts/` + `internal/runtime/` | preserve local machine-readable emission; replace ephemeral key model |
+| `internal/util/crc16.go` | optional compat | `internal/transport/crc16_compat.go` | only keep if needed for test fixtures or compatibility |
+| `README.md` | replace | `README.md` + `docs/` | façade-oriented README; legacy README preserved as reference |
+
+## Porting order
+
+1. import legacy files as reference only
+2. preserve root/main command shape
+3. port A2A lifecycle into `internal/a2a/`
+4. port MCP config-loading idea into `internal/config/`
+5. redesign carrier/receipt emitter against frozen objects
+6. redesign transport against the current canonical runtime and policy model
+
+## Explicit non-goals
+
+- do not compile the legacy transport/emitter as production code
+- do not keep the ephemeral signing-key behavior
+- do not treat the legacy `TritRPC` helper as the final protocol implementation

--- a/docs/legacy/prophet_cli_v2_3/README.md
+++ b/docs/legacy/prophet_cli_v2_3/README.md
@@ -1,0 +1,51 @@
+# Legacy Prophet CLI v2.3 reference
+
+This directory preserves the unpublished `prophet_cli_v2_3_final` attempt as **reference lineage**, not as canonical production code.
+
+## Why this is here
+
+The older CLI has several good ideas we want to preserve while rebuilding the façade and engine split:
+
+- a minimal Cobra root and `cmd/prophet/main.go` entrypoint
+- an early A2A workflow that already models author/test/review/revise/merge phases
+- a transport framing experiment with structured headers, socket IPC, and authenticated encryption
+- local carrier emission with signed JSON records written to disk
+
+## What we keep
+
+- command/workflow shape
+- A2A lifecycle phases
+- MCP config loading pattern
+- the instinct that dry-run should still emit machine-readable carrier-like records
+
+## What we replace
+
+- ephemeral signing keys generated at process start
+- the legacy TritRPC crypto/frame details
+- zero-nonce / prototype transport assumptions
+- the too-small command taxonomy (`prophet` + `a2a run` only)
+- hardcoded demo-only tool IDs and method names
+
+## Integration rule
+
+Nothing in this directory should be compiled directly into the new façade or engine. These files are imported as a legacy reference set. Codex should port ideas out of them intentionally into:
+
+- `internal/cmd/`
+- `internal/a2a/`
+- `internal/config/`
+- `internal/runtime/`
+- `internal/transport/`
+- `internal/receipts/`
+
+## Canonical direction
+
+The new design remains:
+
+- `prophet-cli` = façade and interaction surface
+- `sourceos-sdk/cmd/sourceos-bootstrap` = bootstrap engine source home
+- deterministic CLI verbs are canonical
+- agent flows are overlays on deterministic tools
+
+See also:
+- `.handoff/codex-handoff/08-repo-patch-plans/prophet-cli-existing.md`
+- `.handoff/codex-handoff/06-frozen-specs/CLI_Ergonomics_and_Agent_Hybrid.v1.md`

--- a/docs/legacy/prophet_cli_v2_3/raw/a2a.go.txt
+++ b/docs/legacy/prophet_cli_v2_3/raw/a2a.go.txt
@@ -1,0 +1,22 @@
+package cmd
+import("fmt";"github.com/spf13/cobra";"github.com/socioprophet/prophet/internal/mcp";"github.com/socioprophet/prophet/internal/util")
+func A2ACmd()*cobra.Command{
+  var repo,ticket,cfgPath string; var live bool
+  c:=&cobra.Command{Use:"a2a run", RunE: func(_ *cobra.Command,_ []string) error{
+    if repo=="" { return fmt.Errorf("--repo required") }
+    if cfgPath=="" { cfgPath=".mcp/servers.json" }
+    util.DryRun=!live; cfg,err:=mcp.LoadConfig(cfgPath); if err!=nil { return err }
+    fs,_ := mcp.Find(cfg,"filesystem"); ts,_ := mcp.Find(cfg,"tests"); sc,_ := mcp.Find(cfg,"scmhost"); df,_ := mcp.Find(cfg,"diff")
+    util.Emit("a2a.author.propose", map[string]any{"repo":repo,"ticket":ticket})
+    if live{ _,_ = mcp.Call(fs.Socket, mcp.Header{Mode:"B2",SchemaId:"caps.fs.v1",ContextId:"ctx:fs",Tool:"filesystem",Method:"write"}, []byte(`{"path":"examples/demo_ticket.md","content":"- [x] `+ticket+`\n"}`)) }
+    util.Emit("a2a.author.test", map[string]any{"suite":"quick"}); if live{ _,_ = mcp.Call(ts.Socket, mcp.Header{Mode:"B2",SchemaId:"caps.tests.v1",ContextId:"ctx:tests",Tool:"tests",Method:"run"}, []byte(`{"suite":"quick"}`)) }
+    util.Emit("a2a.author.pr.open", map[string]any{"title":"feat: "+ticket}); if live{ _,_ = mcp.Call(sc.Socket, mcp.Header{Mode:"B2",SchemaId:"caps.scm.v1",ContextId:"ctx:scm",Tool:"scmhost",Method:"open_pr"}, []byte(`{"title":"feat: `+ticket+`","base":"main","head":"feat/`+ticket+`"}`)) }
+    util.Emit("a2a.reviewer.block", map[string]any{"reason":"nit"}); if live{ _,_ = mcp.Call(df.Socket, mcp.Header{Mode:"B2",SchemaId:"caps.diff.v1",ContextId:"ctx:diff",Tool:"diff",Method:"annotate"}, []byte(`{"comment":"nit: add newline"}`)) }
+    util.Emit("a2a.author.revise", map[string]any{"action":"append newline"}); if live{ _,_ = mcp.Call(fs.Socket, mcp.Header{Mode:"B2",SchemaId:"caps.fs.v1",ContextId:"ctx:fs",Tool:"filesystem",Method:"write"}, []byte(`{"path":"examples/demo_ticket.md","content":"- [x] `+ticket+`\n\n"}`)) }
+    util.Emit("a2a.arbiter.merge", map[string]any{"method":"squash"}); if live{ _,_ = mcp.Call(sc.Socket, mcp.Header{Mode:"B2",SchemaId:"caps.scm.v1",ContextId:"ctx:scm",Tool:"scmhost",Method:"merge_pr"}, []byte(`{"method":"squash"}`)) }
+    util.Emit("a2a.done", map[string]any{"repo":repo,"ticket":ticket,"live":live}); return nil
+  }}
+  c.Flags().StringVar(&repo,"repo","", "owner/repo"); c.Flags().StringVar(&ticket,"ticket","DEMO","ticket id")
+  c.Flags().StringVar(&cfgPath,"mcp",".mcp/servers.json","MCP config path"); c.Flags().BoolVar(&live,"live",false,"live mode")
+  return c
+}

--- a/docs/legacy/prophet_cli_v2_3/raw/tritrpc.go.txt
+++ b/docs/legacy/prophet_cli_v2_3/raw/tritrpc.go.txt
@@ -1,0 +1,26 @@
+package mcp
+import("crypto/hkdf";"encoding/binary";"encoding/json";"errors";"io";"net";"os";"sync";"golang.org/x/crypto/sha3";"golang.org/x/crypto/chacha20poly1305";"github.com/socioprophet/prophet/internal/util")
+type Server struct{ ID, Socket, Schema string }
+type Config struct{ Servers []Server `json:"servers"` }
+type Header struct{ Mode,SchemaId,ContextId,Tool,Method string; Nonce uint64 }
+func LoadConfig(path string)(Config,error){ b,err:=os.ReadFile(path); if err!=nil { return Config{},err }; var c Config; return c,json.Unmarshal(b,&c) }
+func Find(c Config, id string)(Server,bool){ for _,s:= range c.Servers{ if s.ID==id {return s,true} } ; return Server{},false }
+func deriveKey(hb []byte)([]byte,error){ hk:=hkdf.New(sha3.New256(), make([]byte,32), hb, []byte("TritRPC-HKDF")); key:=make([]byte, chacha20poly1305.KeySize); _,err:=io.ReadFull(hk,key); return key,err }
+var nonceMu sync.Mutex; var lastNonce=map[string]uint64{}
+func nextNonce(tool string) uint64{ nonceMu.Lock(); defer nonceMu.Unlock(); lastNonce[tool]++; return lastNonce[tool] }
+func Call(sock string, hdr Header, payload []byte)([]byte,error){
+  if hdr.Nonce==0{ hdr.Nonce = nextNonce(hdr.Tool) }
+  hb,_ := json.Marshal(hdr)
+  crc := util.CRC16CCITT(payload); body := append(payload, byte(crc>>8), byte(crc&0xff))
+  key,err:=deriveKey(hb); if err!=nil { return nil, err }
+  aead,_ := chacha20poly1305.New(key); nonce := make([]byte, aead.NonceSize())
+  ct := aead.Seal(nil, nonce, body, hb)
+  conn,err := net.Dial("unix", sock); if err!=nil { return nil, err }; defer conn.Close()
+  var l [8]byte; binary.BigEndian.PutUint32(l[:4], uint32(len(hb))); binary.BigEndian.PutUint32(l[4:], uint32(len(ct)))
+  conn.Write(l[:]); conn.Write(hb); conn.Write(ct)
+  io.ReadFull(conn, l[:]); hl:=int(binary.BigEndian.Uint32(l[:4])); bl:=int(binary.BigEndian.Uint32(l[4:]))
+  rh:=make([]byte,hl); io.ReadFull(conn,rh); rc:=make([]byte,bl); io.ReadFull(conn,rc)
+  rkey,_ := deriveKey(rh); raead,_ := chacha20poly1305.New(rkey); plain,err := raead.Open(nil, nonce, rc, rh); if err!=nil { return nil, err }
+  if len(plain)<2 { return nil, errors.New("short body") }
+  return plain[:len(plain)-2], nil
+}

--- a/internal/legacyv23/README.md
+++ b/internal/legacyv23/README.md
@@ -1,0 +1,18 @@
+# internal/legacyv23
+
+This package namespace is reserved for **selective porting** from the unpublished Prophet CLI v2.3 attempt.
+
+It exists so we can preserve lineage without compiling legacy code directly into the new façade by accident.
+
+Rules:
+- do not copy legacy files here verbatim and wire them into production builds without review
+- first record the legacy file under `docs/legacy/prophet_cli_v2_3/`
+- then port only the useful parts into canonical packages
+
+Primary porting targets:
+- `internal/cmd/`
+- `internal/a2a/`
+- `internal/config/`
+- `internal/runtime/`
+- `internal/transport/`
+- `internal/receipts/`


### PR DESCRIPTION
## Summary
- import the unpublished Prophet v2.3 CLI attempt as documented lineage
- add a migration map from legacy files to the new façade/engine layout
- reserve an internal legacy namespace for controlled selective porting
- preserve raw snapshots of the most important legacy files as reference

## Why
This keeps the best ideas from the old attempt—Cobra root shape, A2A workflow phases, config-driven MCP lookup, and local carrier emission—without promoting the old trust/protocol internals to canonical status.

## Included in this PR
- `docs/legacy/prophet_cli_v2_3/README.md`
- `docs/legacy/prophet_cli_v2_3/MIGRATION_MAP.md`
- `docs/legacy/prophet_cli_v2_3/FILE_MANIFEST.md`
- `docs/legacy/prophet_cli_v2_3/raw/a2a.go.txt`
- `docs/legacy/prophet_cli_v2_3/raw/tritrpc.go.txt`
- `internal/legacyv23/README.md`

## Intentional non-goals
- no direct compilation of the legacy code
- no adoption of the legacy ephemeral signing model
- no adoption of the prototype TritRPC crypto/frame semantics as production behavior

## Review focus
- confirm the keep/replace/adapt mapping
- confirm the legacy namespace and docs layout
- confirm that this should remain reference lineage for Codex rather than production code
