### PR TITLE
Docs: codify canonical mainline and façade boundary

### DIFF
--- a/docs/CANONICAL_MAINLINE_AND_BOUNDARY.md
+++ b/docs/CANONICAL_MAINLINE_AND_BOUNDARY.md
@@ -1,0 +1,31 @@
+# Canonical mainline and boundary
+
+This note makes the current intended repository boundary explicit.
+
+## Boundary
+
+`prophet-cli` is the operator façade.
+It should provide:
+
+- command grammar
+- wrapper behavior
+- machine-readable local output
+- delegation to owning runtime or bootstrap surfaces
+
+It should not become the owner of:
+
+- bootstrap engine logic
+- protocol canon
+- transport crypto or frame semantics
+- long-lived secret material
+
+## Mainline expectation
+
+Feature work should converge into a canonical mainline rather than living indefinitely in split façade/reference branches.
+
+## Related repos
+
+- `TriTRPC` for protocol truth
+- `agentplane` for execution control
+- `sociosphere` for workspace control
+- the owning bootstrap engine repo for bootstrap implementation


### PR DESCRIPTION
## Summary
- add an explicit canonical-mainline and boundary note
- document that `prophet-cli` is the operator façade and should not absorb bootstrap, protocol, or transport canon

## Why
This repo has been moving quickly across multiple branches. This additive note reduces ambiguity about repository role and helps keep follow-on work converging on a single mainline.

## Scope
Additive docs only. No runtime behavior changes.
