### PR TITLE
Add façade docs, A2A skeleton, tests, and CI scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+
+on:
+  push:
+    branches: [ main, sourceos/rev2-1-facade-seed, scaffold3 ]
+  pull_request:
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Download modules
+        run: go mod tidy
+      - name: Test
+        run: go test ./...
+      - name: Vet
+        run: go vet ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/bin/
+/dist/
+/.cache/
+*.log
+*.out
+coverage.out
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+This repository is a façade-only CLI in phase 1.
+
+Please:
+- keep changes small and reviewable
+- prefer deterministic command semantics
+- keep bootstrap logic delegated to `sourceos-bootstrap`
+- preserve explicit docs for boundaries and non-goals
+
+Do not:
+- invent boot or enrollment semantics here
+- add hidden side effects to wrapper commands
+- auto-enable project MCP servers in untrusted workspaces

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+This repository must not contain:
+- enrollment tokens
+- private signing keys
+- token-door secrets
+- hidden bootstrap business logic
+
+Phase 1 rule: keep sensitive semantics in their owning repositories and expose only façade wrappers here.

--- a/cmd/prophet/main.go
+++ b/cmd/prophet/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/socioprophet/prophet-cli/internal/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/docs/AGENT_HYBRID_MODEL.md
+++ b/docs/AGENT_HYBRID_MODEL.md
@@ -1,0 +1,22 @@
+# Agent hybrid model
+
+The repository follows a hybrid model with three surfaces:
+
+1. deterministic CLI
+2. agent assist
+3. agent execute
+
+## Deterministic CLI
+The deterministic CLI is the canonical, documented surface.
+
+## Agent assist
+Read-mostly planning and explanation over deterministic tools.
+
+## Agent execute
+Approval-gated execution that still resolves to deterministic tools.
+
+## Guardrails
+- no bootstrap business logic in this repo
+- no silent plugin installation
+- no automatic project MCP loading in untrusted workspaces
+- no competing command language that bypasses deterministic verbs

--- a/docs/BOOTSTRAP_DELEGATION.md
+++ b/docs/BOOTSTRAP_DELEGATION.md
@@ -1,0 +1,18 @@
+# Bootstrap delegation
+
+`prophet-cli` is a façade. Bootstrap actions delegate to the installed `sourceos-bootstrap` engine.
+
+## Delegated commands
+- `prophet bootstrap doctor`
+- `prophet bootstrap login`
+- `prophet bootstrap build`
+- `prophet bootstrap fetch`
+- `prophet bootstrap write`
+- `prophet bootstrap info`
+- `prophet bootstrap validate <kind> <path>`
+- `prophet bootstrap verify <kind> <path>`
+
+## Rules
+- do not implement bootstrap business logic here
+- do not claim ownership of ReleaseSet, BootReleaseSet, ConfigSource, or TokenDoor semantics here
+- wrapper commands should remain transparent about delegation

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,25 @@
+# Commands
+
+## Deterministic façade commands
+
+### Bootstrap
+- `prophet bootstrap doctor`
+- `prophet bootstrap login`
+- `prophet bootstrap build`
+- `prophet bootstrap fetch`
+- `prophet bootstrap write`
+- `prophet bootstrap info`
+- `prophet bootstrap validate <kind> <path>`
+- `prophet bootstrap verify <kind> <path>`
+
+### Workflow
+- `prophet a2a run`
+
+## Hybrid overlay placeholders
+- `prophet ask`
+- `prophet plan`
+- `prophet agent`
+- `prophet mcp`
+
+## Notes
+These commands are scaffolds in phase 1. The deterministic verbs and delegation boundaries are more important than implementing broad business logic too early.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/socioprophet/prophet-cli
+
+go 1.22
+
+require github.com/spf13/cobra v1.8.1

--- a/internal/a2a/workflow_test.go
+++ b/internal/a2a/workflow_test.go
@@ -1,0 +1,19 @@
+package a2a
+
+import "testing"
+
+func TestDefaultWorkflowHasExpectedPhases(t *testing.T) {
+	wf := Default("demo/repo", "DEMO", false)
+	if wf.Repo != "demo/repo" {
+		t.Fatalf("unexpected repo: %s", wf.Repo)
+	}
+	if len(wf.Phases) != 6 {
+		t.Fatalf("expected 6 phases, got %d", len(wf.Phases))
+	}
+	if wf.Phases[0].Name != "propose" {
+		t.Fatalf("unexpected first phase: %s", wf.Phases[0].Name)
+	}
+	if wf.Phases[len(wf.Phases)-1].Name != "done" {
+		t.Fatalf("unexpected last phase: %s", wf.Phases[len(wf.Phases)-1].Name)
+	}
+}

--- a/internal/cmd/bootstrap.go
+++ b/internal/cmd/bootstrap.go
@@ -1,0 +1,28 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func newBootstrapCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "bootstrap", Short: "Bootstrap facade commands"}
+	cmd.AddCommand(
+		newBootstrapLeaf("doctor", "diagnose host prerequisites"),
+		newBootstrapLeaf("login", "prepare authenticated bootstrap session"),
+		newBootstrapLeaf("build", "submit or describe a bootstrap build request"),
+		newBootstrapLeaf("fetch", "fetch release artifacts"),
+		newBootstrapLeaf("write", "prepare install or recovery media"),
+		newBootstrapLeaf("info", "show bootstrap engine information"),
+		&cobra.Command{Use: "validate <kind> <path>", Short: "Validate a frozen object through the bootstrap engine", Args: cobra.ExactArgs(2), RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet bootstrap validate", "kind": args[0], "path": args[1], "delegated_to": "sourceos-bootstrap", "status": "scaffold"})
+		}},
+		&cobra.Command{Use: "verify <kind> <path>", Short: "Verify a frozen object or artifact through the bootstrap engine", Args: cobra.ExactArgs(2), RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet bootstrap verify", "kind": args[0], "path": args[1], "delegated_to": "sourceos-bootstrap", "status": "scaffold"})
+		}},
+	)
+	return cmd
+}
+
+func newBootstrapLeaf(name, summary string) *cobra.Command {
+	return &cobra.Command{Use: name, Short: summary, RunE: func(cmd *cobra.Command, args []string) error {
+		return emit(map[string]any{"command": "prophet bootstrap " + name, "summary": summary, "delegated_to": "sourceos-bootstrap", "status": "scaffold"})
+	}}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type GlobalFlags struct {
+	Profile string
+	Space   string
+	Output  string
+	Query   string
+	Quiet   bool
+	Debug   bool
+	NoPager bool
+}
+
+var flags GlobalFlags
+
+func Execute() {
+	if err := NewRootCommand().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func NewRootCommand() *cobra.Command {
+	root := &cobra.Command{Use: "prophet", Short: "Prophet facade CLI", SilenceUsage: true}
+	root.PersistentFlags().StringVar(&flags.Profile, "profile", "", "named profile")
+	root.PersistentFlags().StringVar(&flags.Space, "space", "", "execution space")
+	root.PersistentFlags().StringVarP(&flags.Output, "output", "o", "text", "output format")
+	root.PersistentFlags().StringVar(&flags.Query, "query", "", "query expression")
+	root.PersistentFlags().BoolVarP(&flags.Quiet, "quiet", "q", false, "suppress non-essential output")
+	root.PersistentFlags().BoolVar(&flags.Debug, "debug", false, "enable debug output")
+	root.PersistentFlags().BoolVar(&flags.NoPager, "no-pager", false, "disable pager")
+	root.AddCommand(
+		newBootstrapCmd(),
+		newA2ACmd(),
+		newPlaceholderCmd("ask", "Agent assist: explain or inspect without mutating state"),
+		newPlaceholderCmd("plan", "Agent assist: generate a plan over deterministic tools"),
+		newPlaceholderCmd("agent", "Agent execute facade"),
+		newPlaceholderCmd("mcp", "MCP boundary facade"),
+	)
+	return root
+}
+
+func emit(v any) error {
+	switch strings.ToLower(flags.Output) {
+	case "none":
+		return nil
+	case "json", "yaml", "table", "tsv":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(v)
+	default:
+		b, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	}
+}
+
+func newPlaceholderCmd(name, summary string) *cobra.Command {
+	return &cobra.Command{Use: name, Short: summary, RunE: func(cmd *cobra.Command, args []string) error {
+		return emit(map[string]any{"command": name, "summary": summary, "status": "scaffold"})
+	}}
+}

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import "testing"
+
+func TestRootCommandHasExpectedTopLevelCommands(t *testing.T) {
+	root := NewRootCommand()
+	want := map[string]bool{
+		"bootstrap": false,
+		"a2a":       false,
+		"ask":       false,
+		"plan":      false,
+		"agent":     false,
+		"mcp":       false,
+	}
+	for _, c := range root.Commands() {
+		if _, ok := want[c.Name()]; ok {
+			want[c.Name()] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Fatalf("missing top-level command: %s", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add real façade documentation for bootstrap delegation and the hybrid CLI model
- add a compileable Cobra scaffold with root, bootstrap, and workflow commands
- add a simple legacy-derived workflow model under `internal/a2a`
- add tests and a GitHub Actions Go CI workflow
- keep bootstrap business logic out of this repository

## Why
The repository needed to move beyond a handoff dossier and become a real code-bearing façade. PR #1 preserved the unpublished v2.3 CLI as reference lineage, and this PR turns that lineage into a modern scaffold without promoting the old trust/protocol internals.

## Included
- `go.mod`
- `CONTRIBUTING.md`
- `SECURITY.md`
- `.gitignore`
- `cmd/prophet/main.go`
- `internal/cmd/root.go`
- `internal/cmd/bootstrap.go`
- `internal/cmd/workflow.go`
- `internal/a2a/workflow.go`
- `internal/cmd/root_test.go`
- `internal/a2a/workflow_test.go`
- `docs/BOOTSTRAP_DELEGATION.md`
- `docs/CLI_SURFACE_POLICY.md`
- `docs/AGENT_HYBRID_MODEL.md`
- `docs/COMMANDS.md`
- `.github/workflows/ci.yml`

## Explicit boundaries
- this repo remains façade-only
- bootstrap implementation still belongs in `sourceos-sdk/cmd/sourceos-bootstrap`
- no BootReleaseSet / ConfigSource / TokenDoor ownership is introduced here
- no boot/auth/enrollment semantics are invented here

## Relationship to legacy work
Use PR #1 as the legacy canopy/reference input. The new workflow/A2A scaffold deliberately keeps the old phase structure while replacing the old transport and key-management assumptions.
