### PR TITLE
Polish docs, add repo navigation, and extend legacy reference snapshots

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+- describe the change in one short list
+
+## Why
+- explain why this change belongs in `prophet-cli`
+
+## Scope check
+- [ ] facade-only change
+- [ ] no bootstrap engine business logic added here
+- [ ] no boot/auth/enrollment semantics invented here
+- [ ] docs and commands remain aligned with the facade/engine split
+
+## Validation
+- [ ] tests added or updated if needed
+- [ ] `go test ./...` expected to pass
+- [ ] `go vet ./...` expected to pass
+
+## Notes
+- mention any relation to legacy reference material or SourceOS handoff artifacts

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,29 @@
+# Development
+
+This repository is a phase-1 facade CLI.
+
+## Local workflow
+
+Typical commands:
+- `make fmt`
+- `make test`
+- `make vet`
+- `make tidy`
+- `make verify`
+
+## Scope discipline
+
+Do in this repo:
+- command grammar
+- wrapper commands
+- facade docs
+- command-surface tests
+
+Do not do in this repo:
+- bootstrap engine business logic
+- boot or enrollment protocol implementation
+- ownership of ReleaseSet, BootReleaseSet, ConfigSource, or TokenDoor semantics
+
+## Branching
+
+Use small topic branches and keep PRs reviewable.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,9 @@
+# Documentation Index
+
+- Bootstrap Delegation: docs/BOOTSTRAP_DELEGATION.md
+- CLI Surface Policy: docs/CLI_SURFACE_POLICY.md
+- Agent Hybrid Model: docs/AGENT_HYBRID_MODEL.md
+- Commands: docs/COMMANDS.md
+- Development: docs/DEVELOPMENT.md
+- Repo Role: docs/REPO_ROLE.md
+- Legacy Prophet CLI v2.3 reference: docs/legacy/prophet_cli_v2_3/README.md

--- a/docs/REPO_ROLE.md
+++ b/docs/REPO_ROLE.md
@@ -1,0 +1,20 @@
+# Repo Role
+
+`prophet-cli` is the facade repository for the Prophet command surface.
+
+## It owns
+- command grammar
+- wrapper command definitions
+- interactive and hybrid CLI documentation
+- tests that protect command-surface shape
+
+## It does not own
+- bootstrap engine business logic
+- final transport internals
+- final receipt or enrollment semantics
+- ReleaseSet, BootReleaseSet, ConfigSource, or TokenDoor ownership
+
+## Engine boundary
+
+The bootstrap engine source home for phase 1 remains:
+- `sourceos-sdk/cmd/sourceos-bootstrap`

--- a/docs/legacy/prophet_cli_v2_3/raw/main.go.txt
+++ b/docs/legacy/prophet_cli_v2_3/raw/main.go.txt
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/socioprophet/prophet/internal/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/docs/legacy/prophet_cli_v2_3/raw/root.go.txt
+++ b/docs/legacy/prophet_cli_v2_3/raw/root.go.txt
@@ -1,0 +1,5 @@
+package cmd
+import("os";"github.com/spf13/cobra";"github.com/socioprophet/prophet/internal/util")
+var rootCmd=&cobra.Command{Use:"prophet"}
+func init(){rootCmd.PersistentFlags().BoolVar(&util.JsonOut,"json",false,"JSON");rootCmd.PersistentFlags().BoolVar(&util.DryRun,"dry-run",false,"dry-run");rootCmd.AddCommand(A2ACmd())}
+func Execute(){ if err:=rootCmd.Execute(); err!=nil { os.Exit(1) } }


### PR DESCRIPTION
## Summary
- add a docs index, development guide, repo-role note, and PR template
- extend the legacy v2.3 in-repo reference archive with additional raw snapshots
- keep the work based on the current live `main` after the merged scaffold PRs
- avoid touching bootstrap business logic or unfrozen boot/auth semantics

## Why
The repository already moved beyond handoff-only state via the merged scaffold work. This PR is the next small polish tranche: it improves repo navigation and contributor ergonomics, and makes the legacy lineage archive more complete for future controlled porting.

## Included
- `docs/INDEX.md`
- `docs/DEVELOPMENT.md`
- `docs/REPO_ROLE.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `docs/legacy/prophet_cli_v2_3/raw/root.go.txt`
- `docs/legacy/prophet_cli_v2_3/raw/main.go.txt`

## Explicit boundaries
- no bootstrap business logic added here
- no in-place semantic changes to BootReleaseSet / ConfigSource / TokenDoor ownership
- no boot/auth/enrollment semantics invented here
- this remains a facade-only repository
