### PR TITLE
feat(cmd): add vocab runtime plumbing

### DIFF
--- a/internal/cmd/vocab.go
+++ b/internal/cmd/vocab.go
@@ -1,27 +1,30 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/socioprophet/prophet-cli/internal/vocab"
+	"github.com/spf13/cobra"
+)
 
 func newVocabCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "vocab", Short: "Ontogenesis vocabulary and policy-pack façade"}
 	cmd.AddCommand(
-		newVocabLeaf("fetch", "fetch or refresh Ontogenesis semantic assets"),
+		&cobra.Command{Use: "fetch", Short: "fetch or refresh Ontogenesis semantic assets", RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := vocab.Fetch(cmd.Context())
+			if err != nil { return err }
+			resp["command"] = "prophet vocab fetch"
+			return emit(resp)
+		}},
 		&cobra.Command{Use: "validate [graph-path ...]", Short: "Run Ontogenesis semantic-core validation", Args: cobra.ArbitraryArgs, RunE: func(cmd *cobra.Command, args []string) error {
-			return emit(map[string]any{
-				"command":      "prophet vocab validate",
-				"graph_paths":  args,
-				"delegated_to": "socioprophet-standards-knowledge",
-				"validator":    "policy/tools/validate_all.py",
-				"status":       "scaffold",
-			})
+			resp, err := vocab.Validate(cmd.Context(), args)
+			if err != nil { return err }
+			resp["command"] = "prophet vocab validate"
+			return emit(resp)
 		}},
 		&cobra.Command{Use: "promote", Short: "Promote the current validated context set", RunE: func(cmd *cobra.Command, args []string) error {
-			return emit(map[string]any{
-				"command":       "prophet vocab promote",
-				"delegated_to":  "socioprophet-standards-knowledge",
-				"record_target": "/ontology/promotions/<ts>.jsonld",
-				"status":        "scaffold",
-			})
+			resp, err := vocab.Promote(cmd.Context())
+			if err != nil { return err }
+			resp["command"] = "prophet vocab promote"
+			return emit(resp)
 		}},
 		newVocabSRCmd(),
 	)
@@ -32,26 +35,17 @@ func newVocabSRCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "sr", Short: "Symbolic regression façade over Ontogenesis runners"}
 	cmd.AddCommand(
 		&cobra.Command{Use: "run <module>", Short: "Extract, train, and register SR for a module", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
-			return emit(map[string]any{
-				"command":      "prophet vocab sr run",
-				"module":       args[0],
-				"delegated_to": "socioprophet-standards-knowledge",
-				"status":       "scaffold",
-			})
+			resp, err := vocab.SRRun(cmd.Context(), args[0])
+			if err != nil { return err }
+			resp["command"] = "prophet vocab sr run"
+			return emit(resp)
 		}},
 		&cobra.Command{Use: "gate", Short: "Evaluate SR promotion thresholds", RunE: func(cmd *cobra.Command, args []string) error {
-			return emit(map[string]any{
-				"command":      "prophet vocab sr gate",
-				"delegated_to": "socioprophet-standards-knowledge",
-				"status":       "scaffold",
-			})
+			resp, err := vocab.SRGate(cmd.Context())
+			if err != nil { return err }
+			resp["command"] = "prophet vocab sr gate"
+			return emit(resp)
 		}},
 	)
 	return cmd
-}
-
-func newVocabLeaf(name, summary string) *cobra.Command {
-	return &cobra.Command{Use: name, Short: summary, RunE: func(cmd *cobra.Command, args []string) error {
-		return emit(map[string]any{"command": "prophet vocab " + name, "summary": summary, "delegated_to": "socioprophet-standards-knowledge", "status": "scaffold"})
-	}}
 }

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -1,0 +1,36 @@
+package executil
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"time"
+)
+
+type Result struct {
+	Command  []string       `json:"command"`
+	Stdout   string         `json:"stdout,omitempty"`
+	Stderr   string         `json:"stderr,omitempty"`
+	ExitCode int            `json:"exit_code"`
+	Duration time.Duration  `json:"duration_ns"`
+}
+
+func Run(ctx context.Context, argv []string) (Result, error) {
+	res := Result{Command: append([]string(nil), argv...)}
+	if len(argv) == 0 {
+		return res, nil
+	}
+	start := time.Now()
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	res.Stdout = outb.String()
+	res.Stderr = errb.String()
+	res.Duration = time.Since(start)
+	if cmd.ProcessState != nil {
+		res.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	return res, err
+}

--- a/internal/vocab/vocab.go
+++ b/internal/vocab/vocab.go
@@ -1,0 +1,58 @@
+package vocab
+
+import (
+	"context"
+	"path/filepath"
+
+	executil "github.com/socioprophet/prophet-cli/internal/exec"
+)
+
+type Response map[string]any
+
+func Fetch(_ context.Context) (Response, error) {
+	return Response{
+		"delegated_to": "socioprophet-standards-knowledge",
+		"status":       "scaffold",
+		"operation":    "fetch",
+	}, nil
+}
+
+func Validate(ctx context.Context, graphPaths []string) (Response, error) {
+	cmd := []string{"python3", filepath.ToSlash("policy/tools/validate_all.py"), "--data"}
+	cmd = append(cmd, graphPaths...)
+	res, _ := executil.Run(ctx, cmd)
+	return Response{
+		"delegated_to": "socioprophet-standards-knowledge",
+		"status":       "scaffold",
+		"operation":    "validate",
+		"graph_paths":  graphPaths,
+		"validator":    "policy/tools/validate_all.py",
+		"probe":        res,
+	}, nil
+}
+
+func Promote(_ context.Context) (Response, error) {
+	return Response{
+		"delegated_to":  "socioprophet-standards-knowledge",
+		"status":        "scaffold",
+		"operation":     "promote",
+		"record_target": "/ontology/promotions/<ts>.jsonld",
+	}, nil
+}
+
+func SRRun(_ context.Context, module string) (Response, error) {
+	return Response{
+		"delegated_to": "socioprophet-standards-knowledge",
+		"status":       "scaffold",
+		"operation":    "sr_run",
+		"module":       module,
+	}, nil
+}
+
+func SRGate(_ context.Context) (Response, error) {
+	return Response{
+		"delegated_to": "socioprophet-standards-knowledge",
+		"status":       "scaffold",
+		"operation":    "sr_gate",
+	}, nil
+}

--- a/internal/vocab/vocab_test.go
+++ b/internal/vocab/vocab_test.go
@@ -1,0 +1,19 @@
+package vocab
+
+import (
+	"context"
+	"testing"
+)
+
+func TestValidateReportsValidatorPath(t *testing.T) {
+	resp, err := Validate(context.Background(), []string{"graphs/demo.ttl"})
+	if err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if got := resp["validator"]; got != "policy/tools/validate_all.py" {
+		t.Fatalf("unexpected validator path: %v", got)
+	}
+	if got := resp["operation"]; got != "validate" {
+		t.Fatalf("unexpected operation: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on top of #11.

This PR moves the new `vocab` command surface from raw placeholder emission into real internal runtime plumbing.

### Included
- `internal/exec/runner.go` execution helper
- `internal/vocab/vocab.go` internal vocabulary/runtime package
- `internal/vocab/vocab_test.go`
- `internal/cmd/vocab.go` updated to delegate into the internal package instead of hardcoding response maps

## Why

PR #11 establishes the runtime-facing `vocab` façade. This follow-on PR gives it an internal package seam so later work can wire real execution, policy-pack validation, and CI hooks without bloating the Cobra command file.

## Scope

Still intentionally narrow:
- no real shell-out to the standards repo yet beyond a probe-shaped runner seam
- no CI/build hook changes yet
- no K8s shapecheck yet
- no ABD validation wrapper yet

## Review order

1. merge #11
2. merge this PR
