### PR TITLE
feat(cmd): execute vocab validate in standards repo working dir

### DIFF
--- a/internal/cmd/vocab.go
+++ b/internal/cmd/vocab.go
@@ -10,21 +10,27 @@ func newVocabCmd() *cobra.Command {
 	cmd.AddCommand(
 		&cobra.Command{Use: "fetch", Short: "fetch or refresh Ontogenesis semantic assets", RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.Fetch(cmd.Context())
-			if err != nil { return err }
-			resp["command"] = "prophet vocab fetch"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab fetch"
+				_ = emit(resp)
+			}
+			return err
 		}},
 		&cobra.Command{Use: "validate [graph-path ...]", Short: "Run Ontogenesis semantic-core validation", Args: cobra.ArbitraryArgs, RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.Validate(cmd.Context(), args)
-			if err != nil { return err }
-			resp["command"] = "prophet vocab validate"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab validate"
+				_ = emit(resp)
+			}
+			return err
 		}},
 		&cobra.Command{Use: "promote", Short: "Promote the current validated context set", RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.Promote(cmd.Context())
-			if err != nil { return err }
-			resp["command"] = "prophet vocab promote"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab promote"
+				_ = emit(resp)
+			}
+			return err
 		}},
 		newVocabSRCmd(),
 	)
@@ -36,15 +42,19 @@ func newVocabSRCmd() *cobra.Command {
 	cmd.AddCommand(
 		&cobra.Command{Use: "run <module>", Short: "Extract, train, and register SR for a module", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.SRRun(cmd.Context(), args[0])
-			if err != nil { return err }
-			resp["command"] = "prophet vocab sr run"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab sr run"
+				_ = emit(resp)
+			}
+			return err
 		}},
 		&cobra.Command{Use: "gate", Short: "Evaluate SR promotion thresholds", RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.SRGate(cmd.Context())
-			if err != nil { return err }
-			resp["command"] = "prophet vocab sr gate"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab sr gate"
+				_ = emit(resp)
+			}
+			return err
 		}},
 	)
 	return cmd

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -8,20 +8,28 @@ import (
 )
 
 type Result struct {
-	Command  []string       `json:"command"`
-	Stdout   string         `json:"stdout,omitempty"`
-	Stderr   string         `json:"stderr,omitempty"`
-	ExitCode int            `json:"exit_code"`
-	Duration time.Duration  `json:"duration_ns"`
+	Command  []string      `json:"command"`
+	Dir      string        `json:"dir,omitempty"`
+	Stdout   string        `json:"stdout,omitempty"`
+	Stderr   string        `json:"stderr,omitempty"`
+	ExitCode int           `json:"exit_code"`
+	Duration time.Duration `json:"duration_ns"`
 }
 
 func Run(ctx context.Context, argv []string) (Result, error) {
-	res := Result{Command: append([]string(nil), argv...)}
+	return RunInDir(ctx, "", argv)
+}
+
+func RunInDir(ctx context.Context, dir string, argv []string) (Result, error) {
+	res := Result{Command: append([]string(nil), argv...), Dir: dir}
 	if len(argv) == 0 {
 		return res, nil
 	}
 	start := time.Now()
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	var outb, errb bytes.Buffer
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb

--- a/internal/vocab/vocab.go
+++ b/internal/vocab/vocab.go
@@ -2,57 +2,88 @@ package vocab
 
 import (
 	"context"
-	"path/filepath"
+	"os"
 
 	executil "github.com/socioprophet/prophet-cli/internal/exec"
 )
 
+const defaultRepoPath = "../socioprophet-standards-knowledge"
+
 type Response map[string]any
 
+func resolveRepoPath() string {
+	if v := os.Getenv("PROPHET_VOCAB_REPO"); v != "" {
+		return v
+	}
+	return defaultRepoPath
+}
+
+func normalizeGraphPaths(graphPaths []string) []string {
+	if len(graphPaths) == 0 {
+		return []string{"."}
+	}
+	return graphPaths
+}
+
 func Fetch(_ context.Context) (Response, error) {
+	repoPath := resolveRepoPath()
 	return Response{
 		"delegated_to": "socioprophet-standards-knowledge",
 		"status":       "scaffold",
 		"operation":    "fetch",
+		"repo_path":    repoPath,
 	}, nil
 }
 
 func Validate(ctx context.Context, graphPaths []string) (Response, error) {
-	cmd := []string{"python3", filepath.ToSlash("policy/tools/validate_all.py"), "--data"}
-	cmd = append(cmd, graphPaths...)
-	res, _ := executil.Run(ctx, cmd)
+	repoPath := resolveRepoPath()
+	normalized := normalizeGraphPaths(graphPaths)
+	cmd := []string{"python3", "policy/tools/validate_all.py", "--data"}
+	cmd = append(cmd, normalized...)
+	res, err := executil.RunInDir(ctx, repoPath, cmd)
+	status := "ok"
+	if err != nil {
+		status = "failed"
+	}
 	return Response{
 		"delegated_to": "socioprophet-standards-knowledge",
-		"status":       "scaffold",
+		"status":       status,
 		"operation":    "validate",
-		"graph_paths":  graphPaths,
+		"repo_path":    repoPath,
+		"graph_paths":  normalized,
 		"validator":    "policy/tools/validate_all.py",
-		"probe":        res,
-	}, nil
+		"result":       res,
+	}, err
 }
 
 func Promote(_ context.Context) (Response, error) {
+	repoPath := resolveRepoPath()
 	return Response{
 		"delegated_to":  "socioprophet-standards-knowledge",
 		"status":        "scaffold",
 		"operation":     "promote",
+		"repo_path":     repoPath,
 		"record_target": "/ontology/promotions/<ts>.jsonld",
 	}, nil
 }
 
 func SRRun(_ context.Context, module string) (Response, error) {
+	repoPath := resolveRepoPath()
 	return Response{
 		"delegated_to": "socioprophet-standards-knowledge",
 		"status":       "scaffold",
 		"operation":    "sr_run",
+		"repo_path":    repoPath,
 		"module":       module,
 	}, nil
 }
 
 func SRGate(_ context.Context) (Response, error) {
+	repoPath := resolveRepoPath()
 	return Response{
 		"delegated_to": "socioprophet-standards-knowledge",
 		"status":       "scaffold",
 		"operation":    "sr_gate",
+		"repo_path":    repoPath,
 	}, nil
 }

--- a/internal/vocab/vocab_test.go
+++ b/internal/vocab/vocab_test.go
@@ -1,19 +1,17 @@
 package vocab
 
-import (
-	"context"
-	"testing"
-)
+import "testing"
 
-func TestValidateReportsValidatorPath(t *testing.T) {
-	resp, err := Validate(context.Background(), []string{"graphs/demo.ttl"})
-	if err != nil {
-		t.Fatalf("Validate returned error: %v", err)
+func TestResolveRepoPathPrefersEnv(t *testing.T) {
+	t.Setenv("PROPHET_VOCAB_REPO", "/tmp/ontogenesis")
+	if got := resolveRepoPath(); got != "/tmp/ontogenesis" {
+		t.Fatalf("unexpected repo path: %s", got)
 	}
-	if got := resp["validator"]; got != "policy/tools/validate_all.py" {
-		t.Fatalf("unexpected validator path: %v", got)
-	}
-	if got := resp["operation"]; got != "validate" {
-		t.Fatalf("unexpected operation: %v", got)
+}
+
+func TestNormalizeGraphPathsDefaultsToDot(t *testing.T) {
+	got := normalizeGraphPaths(nil)
+	if len(got) != 1 || got[0] != "." {
+		t.Fatalf("unexpected default graph paths: %#v", got)
 	}
 }


### PR DESCRIPTION
## Summary

This PR advances the `vocab` runtime surface by adding real local execution for `prophet vocab validate`.

### Included
- `internal/exec/runner.go` supports execution in a specified working directory
- `internal/vocab/vocab.go` resolves a standards repo path and runs `policy/tools/validate_all.py` there
- `internal/cmd/vocab.go` now emits the returned result payload even on validator failure
- tests for repo-path resolution and default graph-path behavior

## Behavior

`prophet vocab validate` now:
1. resolves the standards repo path from `PROPHET_VOCAB_REPO`, or defaults to `../socioprophet-standards-knowledge`
2. defaults graph paths to `.` when none are provided
3. executes `python3 policy/tools/validate_all.py --data ...` in the standards repo working directory
4. returns structured result data and a non-zero error when validation fails

## Why

The standards chain in `socioprophet-standards-knowledge` is now staged through PRs #28-#31. The runtime CLI needs to be able to invoke that validator contract for real, not merely advertise it.

## Note on review chain

This branch was originally intended to stack on top of #12. The live `feat/vocab-runtime-plumbing` branch is not currently visible in the repository branch list, so this PR is opened against `feat/vocab-surface` as the nearest live review base. Functionally, it carries the runtime-plumbing step forward and can supersede #12 if needed.

## Scope

Still intentionally narrow:
- no CI/build hook changes yet
- no K8s shapecheck yet
- no ABD validation wrapper yet
