### PR TITLE
feat(cmd): add control-node façade surface

### DIFF
--- a/docs/CONTROL_NODE.md
+++ b/docs/CONTROL_NODE.md
@@ -1,0 +1,21 @@
+# control-node command surface
+
+`prophet control-node` is the operator-facing façade for the local-first control-node lane.
+
+## Current subcommands
+
+- `prophet control-node status`
+  - emits the current delegated repo surfaces for contracts, runtime, and execution
+- `prophet control-node process <input.json> <outdir>`
+  - delegates to the `agentplane` local-control-node processor and returns a structured probe envelope
+
+## Current delegation split
+
+- contracts: `SourceOS-Linux/sourceos-spec`
+- runtime: `SocioProphet/prophet-platform`
+- execution/evidence: `SocioProphet/agentplane`
+- workstation/bootstrap: `SociOS-Linux/source-os`
+
+## Why this lives here
+
+`prophet-cli` is the façade command surface. It should expose the operator workflow and delegate into the underlying implementation repos instead of re-owning those semantics.

--- a/internal/cmd/controlnode.go
+++ b/internal/cmd/controlnode.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/socioprophet/prophet-cli/internal/controlnode"
+	"github.com/spf13/cobra"
+)
+
+func newControlNodeCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "control-node", Short: "Local-first control-node façade"}
+	cmd.AddCommand(
+		&cobra.Command{Use: "status", Short: "Show current control-node lane status", RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := controlnode.Status(cmd.Context())
+			if err != nil { return err }
+			resp["command"] = "prophet control-node status"
+			return emit(resp)
+		}},
+		&cobra.Command{Use: "process <input.json> <outdir>", Short: "Process a local control-node handoff through agentplane", Args: cobra.ExactArgs(2), RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := controlnode.Process(cmd.Context(), args[0], args[1])
+			if err != nil { return err }
+			resp["command"] = "prophet control-node process"
+			return emit(resp)
+		}},
+	)
+	return cmd
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -39,6 +39,7 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(
 		newBootstrapCmd(),
 		newVocabCmd(),
+		newControlNodeCmd(),
 		newA2ACmd(),
 		newPlaceholderCmd("ask", "Agent assist: explain or inspect without mutating state"),
 		newPlaceholderCmd("plan", "Agent assist: generate a plan over deterministic tools"),

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -5,13 +5,14 @@ import "testing"
 func TestRootCommandHasExpectedTopLevelCommands(t *testing.T) {
 	root := NewRootCommand()
 	want := map[string]bool{
-		"bootstrap": false,
-		"vocab":     false,
-		"a2a":       false,
-		"ask":       false,
-		"plan":      false,
-		"agent":     false,
-		"mcp":       false,
+		"bootstrap":    false,
+		"vocab":        false,
+		"control-node": false,
+		"a2a":          false,
+		"ask":          false,
+		"plan":         false,
+		"agent":        false,
+		"mcp":          false,
 	}
 	for _, c := range root.Commands() {
 		if _, ok := want[c.Name()]; ok {

--- a/internal/cmd/vocab.go
+++ b/internal/cmd/vocab.go
@@ -10,21 +10,27 @@ func newVocabCmd() *cobra.Command {
 	cmd.AddCommand(
 		&cobra.Command{Use: "fetch", Short: "fetch or refresh Ontogenesis semantic assets", RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.Fetch(cmd.Context())
-			if err != nil { return err }
-			resp["command"] = "prophet vocab fetch"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab fetch"
+				_ = emit(resp)
+			}
+			return err
 		}},
 		&cobra.Command{Use: "validate [graph-path ...]", Short: "Run Ontogenesis semantic-core validation", Args: cobra.ArbitraryArgs, RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.Validate(cmd.Context(), args)
-			if err != nil { return err }
-			resp["command"] = "prophet vocab validate"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab validate"
+				_ = emit(resp)
+			}
+			return err
 		}},
 		&cobra.Command{Use: "promote", Short: "Promote the current validated context set", RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.Promote(cmd.Context())
-			if err != nil { return err }
-			resp["command"] = "prophet vocab promote"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab promote"
+				_ = emit(resp)
+			}
+			return err
 		}},
 		newVocabSRCmd(),
 	)
@@ -36,15 +42,19 @@ func newVocabSRCmd() *cobra.Command {
 	cmd.AddCommand(
 		&cobra.Command{Use: "run <module>", Short: "Extract, train, and register SR for a module", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.SRRun(cmd.Context(), args[0])
-			if err != nil { return err }
-			resp["command"] = "prophet vocab sr run"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab sr run"
+				_ = emit(resp)
+			}
+			return err
 		}},
 		&cobra.Command{Use: "gate", Short: "Evaluate SR promotion thresholds", RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := vocab.SRGate(cmd.Context())
-			if err != nil { return err }
-			resp["command"] = "prophet vocab sr gate"
-			return emit(resp)
+			if resp != nil {
+				resp["command"] = "prophet vocab sr gate"
+				_ = emit(resp)
+			}
+			return err
 		}},
 	)
 	return cmd

--- a/internal/controlnode/controlnode.go
+++ b/internal/controlnode/controlnode.go
@@ -1,0 +1,76 @@
+package controlnode
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+type Response map[string]any
+
+type ExecResult struct {
+	Command  []string      `json:"command"`
+	Stdout   string        `json:"stdout,omitempty"`
+	Stderr   string        `json:"stderr,omitempty"`
+	ExitCode int           `json:"exit_code"`
+	Duration time.Duration `json:"duration_ns"`
+	WorkDir  string        `json:"work_dir,omitempty"`
+}
+
+func repoPath() string {
+	if p := os.Getenv("PROPHET_AGENTPLANE_REPO"); p != "" {
+		return p
+	}
+	return filepath.Clean("../agentplane")
+}
+
+func runInDir(ctx context.Context, dir string, argv []string) (ExecResult, error) {
+	res := ExecResult{Command: append([]string(nil), argv...), WorkDir: dir}
+	if len(argv) == 0 {
+		return res, nil
+	}
+	start := time.Now()
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	res.Stdout = string(out)
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			res.Stderr = string(ee.Stderr)
+			res.ExitCode = ee.ExitCode()
+		} else {
+			res.Stderr = err.Error()
+		}
+	} else if cmd.ProcessState != nil {
+		res.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	res.Duration = time.Since(start)
+	return res, err
+}
+
+func Status(_ context.Context) (Response, error) {
+	return Response{
+		"delegated_to": "agentplane + prophet-platform + source-os",
+		"status": "scaffold",
+		"operation": "status",
+		"agentplane_repo": repoPath(),
+		"runtime_service": "prophet-platform/apps/node-commander",
+		"contracts_repo": "SourceOS-Linux/sourceos-spec",
+	}, nil
+}
+
+func Process(ctx context.Context, inputPath, outDir string) (Response, error) {
+	argv := []string{"python3", filepath.ToSlash("scripts/process_local_control_node_input.py"), inputPath, outDir}
+	res, _ := runInDir(ctx, repoPath(), argv)
+	return Response{
+		"delegated_to": "SocioProphet/agentplane",
+		"status": "scaffold",
+		"operation": "process",
+		"input_path": inputPath,
+		"out_dir": outDir,
+		"processor": "scripts/process_local_control_node_input.py",
+		"probe": res,
+	}, nil
+}

--- a/internal/controlnode/controlnode_test.go
+++ b/internal/controlnode/controlnode_test.go
@@ -1,0 +1,33 @@
+package controlnode
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStatusIncludesContractsRepo(t *testing.T) {
+	resp, err := Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status returned error: %v", err)
+	}
+	if got := resp["contracts_repo"]; got != "SourceOS-Linux/sourceos-spec" {
+		t.Fatalf("unexpected contracts_repo: %v", got)
+	}
+}
+
+func TestProcessReturnsProbeEnvelope(t *testing.T) {
+	resp, err := Process(context.Background(), "input.json", "out")
+	if err != nil {
+		t.Fatalf("Process returned error: %v", err)
+	}
+	if got := resp["operation"]; got != "process" {
+		t.Fatalf("unexpected operation: %v", got)
+	}
+	probe, ok := resp["probe"].(ExecResult)
+	if !ok {
+		t.Fatalf("probe was not ExecResult: %T", resp["probe"])
+	}
+	if len(probe.Command) == 0 || probe.Command[0] != "python3" {
+		t.Fatalf("unexpected probe command: %#v", probe.Command)
+	}
+}

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -8,20 +8,28 @@ import (
 )
 
 type Result struct {
-	Command  []string       `json:"command"`
-	Stdout   string         `json:"stdout,omitempty"`
-	Stderr   string         `json:"stderr,omitempty"`
-	ExitCode int            `json:"exit_code"`
-	Duration time.Duration  `json:"duration_ns"`
+	Command  []string      `json:"command"`
+	Dir      string        `json:"dir,omitempty"`
+	Stdout   string        `json:"stdout,omitempty"`
+	Stderr   string        `json:"stderr,omitempty"`
+	ExitCode int           `json:"exit_code"`
+	Duration time.Duration `json:"duration_ns"`
 }
 
 func Run(ctx context.Context, argv []string) (Result, error) {
-	res := Result{Command: append([]string(nil), argv...)}
+	return RunInDir(ctx, "", argv)
+}
+
+func RunInDir(ctx context.Context, dir string, argv []string) (Result, error) {
+	res := Result{Command: append([]string(nil), argv...), Dir: dir}
 	if len(argv) == 0 {
 		return res, nil
 	}
 	start := time.Now()
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	var outb, errb bytes.Buffer
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb

--- a/internal/vocab/vocab.go
+++ b/internal/vocab/vocab.go
@@ -2,57 +2,88 @@ package vocab
 
 import (
 	"context"
-	"path/filepath"
+	"os"
 
 	executil "github.com/socioprophet/prophet-cli/internal/exec"
 )
 
+const defaultRepoPath = "../socioprophet-standards-knowledge"
+
 type Response map[string]any
 
+func resolveRepoPath() string {
+	if v := os.Getenv("PROPHET_VOCAB_REPO"); v != "" {
+		return v
+	}
+	return defaultRepoPath
+}
+
+func normalizeGraphPaths(graphPaths []string) []string {
+	if len(graphPaths) == 0 {
+		return []string{"."}
+	}
+	return graphPaths
+}
+
 func Fetch(_ context.Context) (Response, error) {
+	repoPath := resolveRepoPath()
 	return Response{
 		"delegated_to": "socioprophet-standards-knowledge",
 		"status":       "scaffold",
 		"operation":    "fetch",
+		"repo_path":    repoPath,
 	}, nil
 }
 
 func Validate(ctx context.Context, graphPaths []string) (Response, error) {
-	cmd := []string{"python3", filepath.ToSlash("policy/tools/validate_all.py"), "--data"}
-	cmd = append(cmd, graphPaths...)
-	res, _ := executil.Run(ctx, cmd)
+	repoPath := resolveRepoPath()
+	normalized := normalizeGraphPaths(graphPaths)
+	cmd := []string{"python3", "policy/tools/validate_all.py", "--data"}
+	cmd = append(cmd, normalized...)
+	res, err := executil.RunInDir(ctx, repoPath, cmd)
+	status := "ok"
+	if err != nil {
+		status = "failed"
+	}
 	return Response{
 		"delegated_to": "socioprophet-standards-knowledge",
-		"status":       "scaffold",
+		"status":       status,
 		"operation":    "validate",
-		"graph_paths":  graphPaths,
+		"repo_path":    repoPath,
+		"graph_paths":  normalized,
 		"validator":    "policy/tools/validate_all.py",
-		"probe":        res,
-	}, nil
+		"result":       res,
+	}, err
 }
 
 func Promote(_ context.Context) (Response, error) {
+	repoPath := resolveRepoPath()
 	return Response{
 		"delegated_to":  "socioprophet-standards-knowledge",
 		"status":        "scaffold",
 		"operation":     "promote",
+		"repo_path":     repoPath,
 		"record_target": "/ontology/promotions/<ts>.jsonld",
 	}, nil
 }
 
 func SRRun(_ context.Context, module string) (Response, error) {
+	repoPath := resolveRepoPath()
 	return Response{
 		"delegated_to": "socioprophet-standards-knowledge",
 		"status":       "scaffold",
 		"operation":    "sr_run",
+		"repo_path":    repoPath,
 		"module":       module,
 	}, nil
 }
 
 func SRGate(_ context.Context) (Response, error) {
+	repoPath := resolveRepoPath()
 	return Response{
 		"delegated_to": "socioprophet-standards-knowledge",
 		"status":       "scaffold",
 		"operation":    "sr_gate",
+		"repo_path":    repoPath,
 	}, nil
 }

--- a/internal/vocab/vocab_test.go
+++ b/internal/vocab/vocab_test.go
@@ -1,19 +1,17 @@
 package vocab
 
-import (
-	"context"
-	"testing"
-)
+import "testing"
 
-func TestValidateReportsValidatorPath(t *testing.T) {
-	resp, err := Validate(context.Background(), []string{"graphs/demo.ttl"})
-	if err != nil {
-		t.Fatalf("Validate returned error: %v", err)
+func TestResolveRepoPathPrefersEnv(t *testing.T) {
+	t.Setenv("PROPHET_VOCAB_REPO", "/tmp/ontogenesis")
+	if got := resolveRepoPath(); got != "/tmp/ontogenesis" {
+		t.Fatalf("unexpected repo path: %s", got)
 	}
-	if got := resp["validator"]; got != "policy/tools/validate_all.py" {
-		t.Fatalf("unexpected validator path: %v", got)
-	}
-	if got := resp["operation"]; got != "validate" {
-		t.Fatalf("unexpected operation: %v", got)
+}
+
+func TestNormalizeGraphPathsDefaultsToDot(t *testing.T) {
+	got := normalizeGraphPaths(nil)
+	if len(got) != 1 || got[0] != "." {
+		t.Fatalf("unexpected default graph paths: %#v", got)
 	}
 }


### PR DESCRIPTION
Add the first operator-facing control-node façade to `prophet-cli`.

Included:
- new top-level `prophet control-node` command
- `status` and `process` subcommands
- internal control-node package that delegates to the local control-node seam processor in `agentplane`
- root command test update
- package-level tests
- small command-surface note under `docs/`

This keeps `prophet-cli` in its façade role while making the local-first control-node lane reachable from one operator command surface.