### PR TITLE
ci: add vocab validate job against standards repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,28 @@ jobs:
         run: go test ./...
       - name: Vet
         run: go vet ./...
+
+  vocab-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout prophet-cli
+        uses: actions/checkout@v4
+      - name: Checkout standards repo
+        uses: actions/checkout@v4
+        with:
+          repository: SocioProphet/socioprophet-standards-knowledge
+          path: socioprophet-standards-knowledge
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install validator dependencies
+        run: python -m pip install --upgrade pip rdflib pyshacl
+      - name: Run vocab validate against standards repo
+        env:
+          PROPHET_VOCAB_REPO: ./socioprophet-standards-knowledge
+        run: |
+          go mod tidy
+          go run ./cmd/prophet vocab validate .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [ main, sourceos/rev2-1-facade-seed, scaffold3 ]
@@ -32,6 +35,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: SocioProphet/socioprophet-standards-knowledge
+          ref: main
           path: socioprophet-standards-knowledge
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary

Adds the first CI enforcement job for the Ontogenesis validator path in `prophet-cli`.

### Included
- extends `.github/workflows/ci.yml` with a `vocab-validate` job
- checks out `SocioProphet/socioprophet-standards-knowledge` beside `prophet-cli`
- installs `rdflib` and `pyshacl`
- runs the same runtime path users now have locally: `go run ./cmd/prophet vocab validate .`

## Why

The `prophet vocab` surface and real local validation path are already on `main`. The next enforcement step is to make CI exercise that same path against the standards repo, so the command surface and the standards contract stop drifting.

## Scope

This PR is intentionally narrow:
- no K8s shapecheck yet
- no ABD validation wrapper yet
- no release workflow changes yet

Those should follow after this CI hook lands.
