### PR TITLE
feat(bindings): add ABD validation façade

### DIFF
--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -1,0 +1,41 @@
+package bindings
+
+import (
+	"context"
+	"os"
+
+	executil "github.com/socioprophet/prophet-cli/internal/exec"
+)
+
+const defaultRepoPath = "../socioprophet-standards-knowledge"
+
+type Response map[string]any
+
+func repoPath() string {
+	if v := os.Getenv("PROPHET_VOCAB_REPO"); v != "" {
+		return v
+	}
+	if v := os.Getenv("PROPHET_STANDARDS_REPO"); v != "" {
+		return v
+	}
+	return defaultRepoPath
+}
+
+func ValidateABD(ctx context.Context, abdPath string) (Response, error) {
+	repo := repoPath()
+	argv := []string{"python3", "Lower/tools/validate_abd.py", "--abd", abdPath, "--json"}
+	res, err := executil.RunInDir(ctx, repo, argv)
+	status := "ok"
+	if err != nil {
+		status = "failed"
+	}
+	return Response{
+		"delegated_to": "socioprophet-standards-knowledge",
+		"operation":    "validate_abd",
+		"status":       status,
+		"repo_path":    repo,
+		"abd_path":     abdPath,
+		"validator":    "Lower/tools/validate_abd.py",
+		"result":       res,
+	}, err
+}

--- a/internal/cmd/bindings.go
+++ b/internal/cmd/bindings.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/socioprophet/prophet-cli/internal/bindings"
+	"github.com/spf13/cobra"
+)
+
+func newBindingsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "bindings", Short: "Atomic bindings façade"}
+	validate := &cobra.Command{Use: "validate", Short: "Validate binding descriptors"}
+	var abdPath string
+	abd := &cobra.Command{Use: "abd", Short: "Validate an Agent Binding Descriptor", RunE: func(cmd *cobra.Command, args []string) error {
+		resp, err := bindings.ValidateABD(cmd.Context(), abdPath)
+		if resp != nil {
+			resp["command"] = "prophet bindings validate abd"
+			_ = emit(resp)
+		}
+		return err
+	}}
+	abd.Flags().StringVar(&abdPath, "abd", "", "path to ABD JSON file relative to the standards repo")
+	_ = abd.MarkFlagRequired("abd")
+	validate.AddCommand(abd)
+	cmd.AddCommand(validate)
+	return cmd
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -39,6 +39,7 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(
 		newBootstrapCmd(),
 		newVocabCmd(),
+		newBindingsCmd(),
 		newControlNodeCmd(),
 		newA2ACmd(),
 		newPlaceholderCmd("ask", "Agent assist: explain or inspect without mutating state"),

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -7,6 +7,7 @@ func TestRootCommandHasExpectedTopLevelCommands(t *testing.T) {
 	want := map[string]bool{
 		"bootstrap":    false,
 		"vocab":        false,
+		"bindings":     false,
 		"control-node": false,
 		"a2a":          false,
 		"ask":          false,


### PR DESCRIPTION
## Summary

Adds the runtime façade for Agent Binding Descriptor validation.

### Added
- `internal/bindings/bindings.go`
- `internal/cmd/bindings.go`
- root-command wiring for `prophet bindings`
- root-command test update for the new top-level command

## Behavior

Adds:

```bash
prophet bindings validate abd --abd <path>
```

The command delegates to the standards repo validator:

```bash
python3 Lower/tools/validate_abd.py --abd <path> --json
```

The standards repo is resolved from:
1. `PROPHET_VOCAB_REPO`
2. `PROPHET_STANDARDS_REPO`
3. `../socioprophet-standards-knowledge`

## Dependency

Depends on `SocioProphet/socioprophet-standards-knowledge` PR #44, which adds:
- `Lower/bindings/abd.schema.json`
- `Lower/tools/validate_abd.py`

## Scope

This is intentionally narrow. It does not add K8s shapecheck yet.
