### PR TITLE
ci: add bindings ABD validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,52 @@ jobs:
         run: |
           go mod tidy
           go run ./cmd/prophet vocab validate .
+
+  bindings-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout prophet-cli
+        uses: actions/checkout@v4
+      - name: Checkout standards repo
+        uses: actions/checkout@v4
+        with:
+          repository: SocioProphet/socioprophet-standards-knowledge
+          ref: main
+          path: socioprophet-standards-knowledge
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install ABD validator dependencies
+        run: python -m pip install --upgrade pip jsonschema rdflib pyshacl
+      - name: Create minimal ABD fixture
+        run: |
+          cat > /tmp/prophet-abd.json <<'JSON'
+          {
+            "apiVersion": "bindings.socioprophet.io/v0.1",
+            "kind": "AgentBindingDescriptor",
+            "metadata": {
+              "name": "ci-smoke"
+            },
+            "bindings": [
+              {
+                "type": "port",
+                "name": "http",
+                "portNumber": 8080
+              },
+              {
+                "type": "socket",
+                "name": "runtime",
+                "socketPath": "/run/prophet/runtime.sock"
+              }
+            ]
+          }
+          JSON
+      - name: Run bindings ABD validation against standards repo
+        env:
+          PROPHET_STANDARDS_REPO: ./socioprophet-standards-knowledge
+        run: |
+          go mod tidy
+          go run ./cmd/prophet bindings validate abd --abd /tmp/prophet-abd.json


### PR DESCRIPTION
## Summary

Adds CI coverage for the `prophet bindings validate abd` runtime path.

### Included
- new `bindings-validate` job in `.github/workflows/ci.yml`
- checkout of `SocioProphet/socioprophet-standards-knowledge`
- installation of `jsonschema`, `rdflib`, and `pyshacl`
- generated minimal ABD smoke fixture
- execution of:

```bash
go run ./cmd/prophet bindings validate abd --abd /tmp/prophet-abd.json
```

## Why

The standards repo now has the ABD schema and validator, and `prophet-cli` now exposes the ABD validation façade. This PR makes CI exercise the runtime path so the CLI and standards contract stop drifting.

## Scope

CI-only. K8s shapecheck remains the next runtime enforcement slice.
