### PR TITLE
feat(k8s): add manifest shapecheck façade

### DIFF
--- a/internal/cmd/k8s.go
+++ b/internal/cmd/k8s.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/socioprophet/prophet-cli/internal/k8s"
+	"github.com/spf13/cobra"
+)
+
+func newK8sCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "k8s", Short: "Kubernetes policy façade"}
+	shapecheck := &cobra.Command{Use: "shapecheck <manifest-path>...", Short: "Run K8s manifest shape checks", Args: cobra.MinimumNArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+		resp, err := k8s.Shapecheck(cmd.Context(), args)
+		if resp != nil {
+			resp["command"] = "prophet k8s shapecheck"
+			_ = emit(resp)
+		}
+		return err
+	}}
+	cmd.AddCommand(shapecheck)
+	return cmd
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -40,6 +40,7 @@ func NewRootCommand() *cobra.Command {
 		newBootstrapCmd(),
 		newVocabCmd(),
 		newBindingsCmd(),
+		newK8sCmd(),
 		newControlNodeCmd(),
 		newA2ACmd(),
 		newPlaceholderCmd("ask", "Agent assist: explain or inspect without mutating state"),

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -8,6 +8,7 @@ func TestRootCommandHasExpectedTopLevelCommands(t *testing.T) {
 		"bootstrap":    false,
 		"vocab":        false,
 		"bindings":     false,
+		"k8s":          false,
 		"control-node": false,
 		"a2a":          false,
 		"ask":          false,

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -1,0 +1,42 @@
+package k8s
+
+import (
+	"context"
+	"os"
+
+	executil "github.com/socioprophet/prophet-cli/internal/exec"
+)
+
+const defaultRepoPath = "../socioprophet-standards-knowledge"
+
+type Response map[string]any
+
+func repoPath() string {
+	if v := os.Getenv("PROPHET_VOCAB_REPO"); v != "" {
+		return v
+	}
+	if v := os.Getenv("PROPHET_STANDARDS_REPO"); v != "" {
+		return v
+	}
+	return defaultRepoPath
+}
+
+func Shapecheck(ctx context.Context, manifestPaths []string) (Response, error) {
+	repo := repoPath()
+	argv := []string{"python3", "k8s/tools/shapecheck.py", "--json", "--manifest"}
+	argv = append(argv, manifestPaths...)
+	res, err := executil.RunInDir(ctx, repo, argv)
+	status := "ok"
+	if err != nil {
+		status = "failed"
+	}
+	return Response{
+		"delegated_to":   "socioprophet-standards-knowledge",
+		"operation":      "shapecheck",
+		"status":         status,
+		"repo_path":      repo,
+		"manifest_paths": manifestPaths,
+		"validator":      "k8s/tools/shapecheck.py",
+		"result":         res,
+	}, err
+}


### PR DESCRIPTION
## Summary

Adds the runtime façade for K8s manifest shapecheck.

### Added
- `internal/k8s/k8s.go`
- `internal/cmd/k8s.go`
- root-command wiring for `prophet k8s`
- root-command test update for the new top-level command

## Behavior

Adds:

```bash
prophet k8s shapecheck <manifest-path>...
```

The command delegates to the standards repo validator:

```bash
python3 k8s/tools/shapecheck.py --json --manifest <manifest-path>...
```

The standards repo is resolved from:
1. `PROPHET_VOCAB_REPO`
2. `PROPHET_STANDARDS_REPO`
3. `../socioprophet-standards-knowledge`

## Dependency

Depends on the now-merged `socioprophet-standards-knowledge` K8s shapecheck contract, which added:
- `k8s/shapes/k8s.shacl.ttl`
- `k8s/tools/shapecheck.py`

## Scope

This is intentionally narrow. CI coverage for this command should follow in the next PR.
