### PR TITLE
ci: add k8s shapecheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,46 @@ jobs:
         run: |
           go mod tidy
           go run ./cmd/prophet bindings validate abd --abd /tmp/prophet-abd.json
+
+  k8s-shapecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout prophet-cli
+        uses: actions/checkout@v4
+      - name: Checkout standards repo
+        uses: actions/checkout@v4
+        with:
+          repository: SocioProphet/socioprophet-standards-knowledge
+          ref: main
+          path: socioprophet-standards-knowledge
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install K8s shapecheck dependencies
+        run: python -m pip install --upgrade pip pyyaml rdflib pyshacl
+      - name: Create minimal K8s Service fixture
+        run: |
+          cat > /tmp/prophet-service.yaml <<'YAML'
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: prophet-ci
+          spec:
+            type: NodePort
+            selector:
+              app: prophet-ci
+            ports:
+              - name: http
+                port: 80
+                targetPort: 8080
+                nodePort: 30080
+          YAML
+      - name: Run K8s shapecheck against standards repo
+        env:
+          PROPHET_STANDARDS_REPO: ./socioprophet-standards-knowledge
+        run: |
+          go mod tidy
+          go run ./cmd/prophet k8s shapecheck /tmp/prophet-service.yaml


### PR DESCRIPTION
## Summary

Adds CI coverage for the `prophet k8s shapecheck` runtime path.

### Included
- new `k8s-shapecheck` job in `.github/workflows/ci.yml`
- checkout of `SocioProphet/socioprophet-standards-knowledge`
- installation of `pyyaml`, `rdflib`, and `pyshacl`
- generated minimal NodePort Service manifest
- execution of:

```bash
go run ./cmd/prophet k8s shapecheck /tmp/prophet-service.yaml
```

## Why

The standards repo now has the K8s shapecheck contract, and `prophet-cli` now exposes the K8s shapecheck façade. This PR makes CI exercise the runtime path so the CLI and standards contract stop drifting.

## Scope

CI-only. Broader K8s policy coverage should follow in the standards repo after this smoke gate lands.
