### PR TITLE
ci: consume committed semantic-core fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,35 +71,12 @@ jobs:
           python-version: '3.11'
       - name: Install ABD validator dependencies
         run: python -m pip install --upgrade pip jsonschema rdflib pyshacl
-      - name: Create minimal ABD fixture
-        run: |
-          cat > /tmp/prophet-abd.json <<'JSON'
-          {
-            "apiVersion": "bindings.socioprophet.io/v0.1",
-            "kind": "AgentBindingDescriptor",
-            "metadata": {
-              "name": "ci-smoke"
-            },
-            "bindings": [
-              {
-                "type": "port",
-                "name": "http",
-                "portNumber": 8080
-              },
-              {
-                "type": "socket",
-                "name": "runtime",
-                "socketPath": "/run/prophet/runtime.sock"
-              }
-            ]
-          }
-          JSON
       - name: Run bindings ABD validation against standards repo
         env:
           PROPHET_STANDARDS_REPO: ./socioprophet-standards-knowledge
         run: |
           go mod tidy
-          go run ./cmd/prophet bindings validate abd --abd /tmp/prophet-abd.json
+          go run ./cmd/prophet bindings validate abd --abd fixtures/semantic-core/abd/valid-port-socket.json
 
   k8s-shapecheck:
     runs-on: ubuntu-latest
@@ -120,26 +97,9 @@ jobs:
           python-version: '3.11'
       - name: Install K8s shapecheck dependencies
         run: python -m pip install --upgrade pip pyyaml rdflib pyshacl
-      - name: Create minimal K8s Service fixture
-        run: |
-          cat > /tmp/prophet-service.yaml <<'YAML'
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: prophet-ci
-          spec:
-            type: NodePort
-            selector:
-              app: prophet-ci
-            ports:
-              - name: http
-                port: 80
-                targetPort: 8080
-                nodePort: 30080
-          YAML
       - name: Run K8s shapecheck against standards repo
         env:
           PROPHET_STANDARDS_REPO: ./socioprophet-standards-knowledge
         run: |
           go mod tidy
-          go run ./cmd/prophet k8s shapecheck /tmp/prophet-service.yaml
+          go run ./cmd/prophet k8s shapecheck fixtures/semantic-core/k8s/valid-nodeport-service.yaml


### PR DESCRIPTION
## Summary

Updates CI to consume committed semantic-core smoke fixtures from `SocioProphet/socioprophet-standards-knowledge` instead of generating equivalent ABD and K8s fixtures inline.

### Changed
- `bindings-validate` now runs against `fixtures/semantic-core/abd/valid-port-socket.json`
- `k8s-shapecheck` now runs against `fixtures/semantic-core/k8s/valid-nodeport-service.yaml`
- removes inline heredoc fixture generation from the workflow

## Why

The standards repo now owns canonical smoke fixtures. The runtime CI should consume those stable fixture paths so validation inputs are reviewed, reusable, and shared across local CLI, CI, and release gates.

## Scope

CI-only. No command behavior changes.
