### PR TITLE
ci: exercise expanded k8s semantic fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,4 +102,8 @@ jobs:
           PROPHET_STANDARDS_REPO: ./socioprophet-standards-knowledge
         run: |
           go mod tidy
-          go run ./cmd/prophet k8s shapecheck fixtures/semantic-core/k8s/valid-nodeport-service.yaml
+          go run ./cmd/prophet k8s shapecheck \
+            fixtures/semantic-core/k8s/valid-nodeport-service.yaml \
+            fixtures/semantic-core/k8s/valid-deployment-service-ingress.yaml \
+            fixtures/semantic-core/k8s/valid-k3s-ingress.yaml \
+            fixtures/semantic-core/k8s/valid-kubeedge-deployment.yaml


### PR DESCRIPTION
## Summary

Updates the existing K8s shapecheck CI job to exercise the expanded semantic-core fixture set now available in `socioprophet-standards-knowledge`.

### Changed
The `k8s-shapecheck` job now validates:
- `fixtures/semantic-core/k8s/valid-nodeport-service.yaml`
- `fixtures/semantic-core/k8s/valid-deployment-service-ingress.yaml`
- `fixtures/semantic-core/k8s/valid-k3s-ingress.yaml`
- `fixtures/semantic-core/k8s/valid-kubeedge-deployment.yaml`

## Why

The standards repo now covers Deployment selector checks, Ingress/TLS checks, K3s ingress-class policy, and KubeEdge edge-node placement. Runtime CI should exercise those fixtures so the CLI gate tracks the broader standards contract.

## Scope

CI-only. No command behavior changes.
