### PR TITLE
Add Lattice Studio command surface facade

### DIFF
--- a/.github/workflows/lattice-studio-commands.yml
+++ b/.github/workflows/lattice-studio-commands.yml
@@ -1,0 +1,23 @@
+name: lattice-studio-commands
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate Lattice Studio command surface
+        run: python scripts/validate_lattice_studio_commands.py
+      - name: Check facade script syntax
+        run: bash -n scripts/lattice-studio.sh

--- a/manifests/lattice-studio-commands.json
+++ b/manifests/lattice-studio-commands.json
@@ -1,0 +1,37 @@
+{
+  "apiVersion": "cli.socioprophet.dev/v1",
+  "kind": "ProphetCliCommandSurface",
+  "metadata": {
+    "name": "lattice-studio",
+    "version": "0.1.0"
+  },
+  "delegatesTo": {
+    "repo": "SocioProphet/prophet-platform",
+    "module": "lattice_studio.cli",
+    "path": "apps/lattice-studio"
+  },
+  "commands": [
+    "create-session",
+    "emit-demo-catalog",
+    "emit-platform-records",
+    "emit-atlas-context",
+    "emit-ontogenesis-context",
+    "emit-paas-plan",
+    "emit-local-dev",
+    "emit-memory",
+    "emit-lampstand-demo"
+  ],
+  "surfaces": [
+    "lattice-studio",
+    "datahub",
+    "sourceos-local",
+    "socios-linux",
+    "atlas",
+    "ontogenesis",
+    "lampstand-local-search",
+    "memory-mesh",
+    "porter-paas-devops",
+    "openclaw",
+    "agentplane"
+  ]
+}

--- a/scripts/lattice-studio.sh
+++ b/scripts/lattice-studio.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prophet CLI facade for the Lattice Studio command surface.
+#
+# Expected local checkout layout:
+#   ~/dev/prophet-cli
+#   ~/dev/prophet-platform
+#
+# This script delegates to prophet-platform/apps/lattice-studio without
+# duplicating implementation logic in the CLI facade repo.
+
+ROOT_DIR="${PROPHET_PLATFORM_DIR:-$HOME/dev/prophet-platform}"
+STUDIO_SRC="$ROOT_DIR/apps/lattice-studio/src"
+
+if [[ ! -d "$STUDIO_SRC" ]]; then
+  echo "prophet-cli: missing Lattice Studio source at $STUDIO_SRC" >&2
+  echo "Set PROPHET_PLATFORM_DIR or clone SocioProphet/prophet-platform under ~/dev." >&2
+  exit 2
+fi
+
+export PYTHONPATH="$STUDIO_SRC${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m lattice_studio.cli "$@"

--- a/scripts/validate_lattice_studio_commands.py
+++ b/scripts/validate_lattice_studio_commands.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Validate Prophet CLI Lattice Studio command manifest."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_COMMANDS = {
+    "create-session",
+    "emit-demo-catalog",
+    "emit-platform-records",
+    "emit-atlas-context",
+    "emit-ontogenesis-context",
+    "emit-paas-plan",
+    "emit-local-dev",
+    "emit-memory",
+    "emit-lampstand-demo",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate(path: Path) -> None:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    require(doc.get("apiVersion") == "cli.socioprophet.dev/v1", "apiVersion mismatch")
+    require(doc.get("kind") == "ProphetCliCommandSurface", "kind mismatch")
+    delegates = doc.get("delegatesTo")
+    require(isinstance(delegates, dict), "delegatesTo must be object")
+    require(delegates.get("repo") == "SocioProphet/prophet-platform", "delegate repo mismatch")
+    commands = set(doc.get("commands", []))
+    require(REQUIRED_COMMANDS.issubset(commands), f"missing commands: {sorted(REQUIRED_COMMANDS - commands)}")
+
+
+def main() -> int:
+    try:
+        validate(Path("manifests/lattice-studio-commands.json"))
+        print("PASS manifests/lattice-studio-commands.json")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL manifests/lattice-studio-commands.json: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a Prophet CLI facade for the Lattice Studio command surface.

## What changed

- Adds `scripts/lattice-studio.sh` delegating to `prophet-platform/apps/lattice-studio`.
- Adds `manifests/lattice-studio-commands.json`.
- Adds validator for the command manifest.
- Adds CI to validate the manifest and shell syntax.

## Why

`prophet-cli` is the facade repo for the Prophet command surface and SourceOS bootstrap delegation. It needs to expose the Lattice Studio commands for sessions, catalog, platform records, Atlas, Ontogenesis, PaaS, local dev, memory, and Lampstand/DataHub promotion without duplicating implementation logic.
