### PR TITLE
Expose placement and notebook promotion command surfaces

### DIFF
--- a/.github/workflows/lattice-studio-commands.yml
+++ b/.github/workflows/lattice-studio-commands.yml
@@ -20,4 +20,9 @@ jobs:
       - name: Validate Lattice Studio command surface
         run: python scripts/validate_lattice_studio_commands.py
       - name: Check facade script syntax
-        run: bash -n scripts/lattice-studio.sh
+        run: |
+          bash -n scripts/lattice-studio.sh
+          bash -n scripts/lattice-byoc.sh
+          bash -n scripts/lattice-m2-placement.sh
+          bash -n scripts/lattice-nb-run.sh
+          bash -n scripts/lattice-promote.sh

--- a/manifests/lattice-studio-commands.json
+++ b/manifests/lattice-studio-commands.json
@@ -3,7 +3,7 @@
   "kind": "ProphetCliCommandSurface",
   "metadata": {
     "name": "lattice-studio",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "delegatesTo": {
     "repo": "SocioProphet/prophet-platform",
@@ -19,7 +19,13 @@
     "emit-paas-plan",
     "emit-local-dev",
     "emit-memory",
-    "emit-lampstand-demo"
+    "emit-lampstand-demo",
+    "emit-notebook-plane",
+    "emit-execution",
+    "lattice-byoc",
+    "lattice-m2-placement",
+    "lattice-nb-run",
+    "lattice-promote"
   ],
   "surfaces": [
     "lattice-studio",
@@ -32,6 +38,11 @@
     "memory-mesh",
     "porter-paas-devops",
     "openclaw",
-    "agentplane"
+    "agentplane",
+    "byoc",
+    "cloudshell-fog",
+    "m2-topolvm",
+    "notebook-launch",
+    "notebook-promotion"
   ]
 }

--- a/scripts/lattice-byoc.sh
+++ b/scripts/lattice-byoc.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${PROPHET_PLATFORM_DIR:-$HOME/dev/prophet-platform}"
+STUDIO_SRC="$ROOT_DIR/apps/lattice-studio/src"
+
+if [[ ! -d "$STUDIO_SRC" ]]; then
+  echo "prophet-cli: missing Lattice Studio source at $STUDIO_SRC" >&2
+  echo "Set PROPHET_PLATFORM_DIR or clone SocioProphet/prophet-platform under ~/dev." >&2
+  exit 2
+fi
+
+export PYTHONPATH="$STUDIO_SRC${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m lattice_studio.byoc_cli "$@"

--- a/scripts/lattice-m2-placement.sh
+++ b/scripts/lattice-m2-placement.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${PROPHET_PLATFORM_DIR:-$HOME/dev/prophet-platform}"
+STUDIO_SRC="$ROOT_DIR/apps/lattice-studio/src"
+
+if [[ ! -d "$STUDIO_SRC" ]]; then
+  echo "prophet-cli: missing Lattice Studio source at $STUDIO_SRC" >&2
+  echo "Set PROPHET_PLATFORM_DIR or clone SocioProphet/prophet-platform under ~/dev." >&2
+  exit 2
+fi
+
+export PYTHONPATH="$STUDIO_SRC${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m lattice_studio.m2_topolvm_cli "$@"

--- a/scripts/lattice-nb-run.sh
+++ b/scripts/lattice-nb-run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${PROPHET_PLATFORM_DIR:-$HOME/dev/prophet-platform}"
+STUDIO_SRC="$ROOT_DIR/apps/lattice-studio/src"
+
+if [[ ! -d "$STUDIO_SRC" ]]; then
+  echo "prophet-cli: missing Lattice Studio source at $STUDIO_SRC" >&2
+  echo "Set PROPHET_PLATFORM_DIR or clone SocioProphet/prophet-platform under ~/dev." >&2
+  exit 2
+fi
+
+export PYTHONPATH="$STUDIO_SRC${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m lattice_studio.notebook_launch_cli "$@"

--- a/scripts/lattice-promote.sh
+++ b/scripts/lattice-promote.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${PROPHET_PLATFORM_DIR:-$HOME/dev/prophet-platform}"
+STUDIO_SRC="$ROOT_DIR/apps/lattice-studio/src"
+
+if [[ ! -d "$STUDIO_SRC" ]]; then
+  echo "prophet-cli: missing Lattice Studio source at $STUDIO_SRC" >&2
+  echo "Set PROPHET_PLATFORM_DIR or clone SocioProphet/prophet-platform under ~/dev." >&2
+  exit 2
+fi
+
+export PYTHONPATH="$STUDIO_SRC${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m lattice_studio.notebook_promotion_cli "$@"

--- a/scripts/validate_lattice_studio_commands.py
+++ b/scripts/validate_lattice_studio_commands.py
@@ -17,6 +17,19 @@ REQUIRED_COMMANDS = {
     "emit-local-dev",
     "emit-memory",
     "emit-lampstand-demo",
+    "emit-notebook-plane",
+    "emit-execution",
+    "lattice-byoc",
+    "lattice-m2-placement",
+    "lattice-nb-run",
+    "lattice-promote",
+}
+REQUIRED_SURFACES = {
+    "byoc",
+    "cloudshell-fog",
+    "m2-topolvm",
+    "notebook-launch",
+    "notebook-promotion",
 }
 
 
@@ -34,6 +47,8 @@ def validate(path: Path) -> None:
     require(delegates.get("repo") == "SocioProphet/prophet-platform", "delegate repo mismatch")
     commands = set(doc.get("commands", []))
     require(REQUIRED_COMMANDS.issubset(commands), f"missing commands: {sorted(REQUIRED_COMMANDS - commands)}")
+    surfaces = set(doc.get("surfaces", []))
+    require(REQUIRED_SURFACES.issubset(surfaces), f"missing surfaces: {sorted(REQUIRED_SURFACES - surfaces)}")
 
 
 def main() -> int:


### PR DESCRIPTION
Adds Prophet CLI facades for BYOC placement, SourceOS M2 placement, notebook launch dry-runs, and notebook promotion. Updates the command manifest, validator, and CI syntax checks so these command surfaces are enforced.