### PR TITLE
Expose placement decision command surface

### DIFF
--- a/.github/workflows/lattice-studio-commands.yml
+++ b/.github/workflows/lattice-studio-commands.yml
@@ -26,3 +26,4 @@ jobs:
           bash -n scripts/lattice-m2-placement.sh
           bash -n scripts/lattice-nb-run.sh
           bash -n scripts/lattice-promote.sh
+          bash -n scripts/lattice-place.sh

--- a/manifests/lattice-studio-commands.json
+++ b/manifests/lattice-studio-commands.json
@@ -3,7 +3,7 @@
   "kind": "ProphetCliCommandSurface",
   "metadata": {
     "name": "lattice-studio",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "delegatesTo": {
     "repo": "SocioProphet/prophet-platform",
@@ -25,7 +25,8 @@
     "lattice-byoc",
     "lattice-m2-placement",
     "lattice-nb-run",
-    "lattice-promote"
+    "lattice-promote",
+    "lattice-place"
   ],
   "surfaces": [
     "lattice-studio",
@@ -43,6 +44,7 @@
     "cloudshell-fog",
     "m2-topolvm",
     "notebook-launch",
-    "notebook-promotion"
+    "notebook-promotion",
+    "placement-decision"
   ]
 }

--- a/scripts/lattice-place.sh
+++ b/scripts/lattice-place.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${PROPHET_PLATFORM_DIR:-$HOME/dev/prophet-platform}"
+STUDIO_SRC="$ROOT_DIR/apps/lattice-studio/src"
+
+if [[ ! -d "$STUDIO_SRC" ]]; then
+  echo "prophet-cli: missing Lattice Studio source at $STUDIO_SRC" >&2
+  echo "Set PROPHET_PLATFORM_DIR or clone SocioProphet/prophet-platform under ~/dev." >&2
+  exit 2
+fi
+
+export PYTHONPATH="$STUDIO_SRC${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m lattice_studio.placement_decision_cli "$@"

--- a/scripts/validate_lattice_studio_commands.py
+++ b/scripts/validate_lattice_studio_commands.py
@@ -23,6 +23,7 @@ REQUIRED_COMMANDS = {
     "lattice-m2-placement",
     "lattice-nb-run",
     "lattice-promote",
+    "lattice-place",
 }
 REQUIRED_SURFACES = {
     "byoc",
@@ -30,6 +31,7 @@ REQUIRED_SURFACES = {
     "m2-topolvm",
     "notebook-launch",
     "notebook-promotion",
+    "placement-decision",
 }
 
 


### PR DESCRIPTION
Adds the `lattice-place` facade for Lattice Studio placement dry-run reports. Updates the command manifest, validator, and CI syntax checks so placement decision reporting is available from Prophet CLI.