### PR TITLE
Implement Prophet suite facade command surface

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,27 @@
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Validate
+        run: make validate
+
+      - name: Release dry run
+        run: make release-dry-run

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,26 @@
 SHELL := /bin/bash
 
-.PHONY: help fmt test vet tidy verify
+BIN := prophet
+DIST_DIR := dist
+VERSION ?= 0.1.0-dev
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+GOOS ?= $(shell go env GOOS 2>/dev/null || uname -s | tr A-Z a-z)
+GOARCH ?= $(shell go env GOARCH 2>/dev/null || uname -m)
+DIST_NAME := $(BIN)_$(VERSION)_$(GOOS)_$(GOARCH)
+LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+
+.PHONY: help fmt build test vet tidy validate verify dist release-dry-run clean
 
 help:
-	@echo "Targets: fmt test vet tidy verify"
+	@echo "Targets: fmt build test vet tidy validate verify dist release-dry-run clean"
 
 fmt:
 	gofmt -w ./cmd ./internal
+
+build:
+	mkdir -p bin
+	go build -ldflags "$(LDFLAGS)" -o bin/$(BIN) ./cmd/prophet
 
 test:
 	go test ./...
@@ -17,4 +31,26 @@ vet:
 tidy:
 	go mod tidy
 
-verify: fmt vet test
+validate: build vet test
+	bin/$(BIN) --help >/tmp/prophet-help.txt
+	bin/$(BIN) version >/tmp/prophet-version.json
+	bin/$(BIN) doctor >/tmp/prophet-doctor.json
+	bin/$(BIN) self-test >/tmp/prophet-self-test.json
+	bin/$(BIN) emit-evidence >/tmp/prophet-evidence.json
+	bin/$(BIN) devtools profile list >/tmp/prophet-devtools-profiles.json
+	bin/$(BIN) lab list >/tmp/prophet-labs.json
+	bin/$(BIN) sourceos carry list >/tmp/prophet-sourceos-carry-list.json
+	bin/$(BIN) holmes search "truth and evidence" >/tmp/prophet-holmes-search.json
+
+verify: fmt validate
+
+dist: validate
+	mkdir -p $(DIST_DIR)
+	cp bin/$(BIN) $(DIST_DIR)/$(DIST_NAME)
+	(cd $(DIST_DIR) && sha256sum $(DIST_NAME) > $(DIST_NAME).sha256)
+
+release-dry-run: dist
+	@echo "release dry-run complete: $(DIST_DIR)/$(DIST_NAME)"
+
+clean:
+	rm -rf bin $(DIST_DIR)

--- a/docs/SUITE_COMMAND_SURFACE.md
+++ b/docs/SUITE_COMMAND_SURFACE.md
@@ -1,0 +1,88 @@
+# Prophet Suite Command Surface
+
+`prophet` is the facade command for SocioProphet, SourceOS, Holmes, and the functional AI product suite.
+
+Specialized binaries may exist, but every product path should also be available through `prophet`.
+
+## Golden path
+
+```bash
+brew tap SocioProphet/prophet
+brew install prophet-cli
+prophet doctor
+prophet devtools profile list
+prophet sourceos carry list
+prophet holmes analyze ./document.txt
+```
+
+## Command families
+
+### Global
+
+```bash
+prophet version
+prophet doctor
+prophet self-test
+prophet emit-evidence
+```
+
+### SourceOS
+
+```bash
+prophet sourceos install --target m2 --channel dev
+prophet sourceos carry list
+prophet sourceos carry validate
+prophet sourceos carry doctor
+prophet sourceos carry emit-evidence
+```
+
+### Developer tools and labs
+
+```bash
+prophet devtools doctor
+prophet devtools profile list
+prophet devtools profile apply core,ai-core,containers
+prophet lab list
+prophet lab enable image video embedding nlplab
+prophet lab status
+```
+
+### Holmes and language intelligence
+
+```bash
+prophet holmes analyze ./document.txt
+prophet holmes search "claim"
+prophet holmes graph ./document.txt
+prophet holmes govern ./document.txt
+```
+
+### Model, guardrail, and agent registry
+
+```bash
+prophet model route --task summarize --privacy local-first
+prophet guardrail test examples/policy.json examples/input.json
+prophet agent registry list
+```
+
+## Delegation split
+
+`prophet-cli` owns facade semantics and user experience. It should delegate to product binaries where they exist:
+
+- `sourceos-ai` for SourceOS carry commands.
+- `holmes` for language intelligence commands.
+- `model-router` for model/service routing commands.
+- `guardrail-fabric` for guardrail policy evaluation.
+- `agent-registry` for agent spec/identity/session registry commands.
+
+Missing delegated tools must be reported as `not-yet-wired`, not as success.
+
+## Release contract
+
+Every delegated binary should implement:
+
+```bash
+<tool> --version
+<tool> doctor
+<tool> self-test
+<tool> emit-evidence
+```

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -37,15 +37,25 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().BoolVar(&flags.Debug, "debug", false, "enable debug output")
 	root.PersistentFlags().BoolVar(&flags.NoPager, "no-pager", false, "disable pager")
 	root.AddCommand(
+		newSuiteVersionCmd(),
+		newSuiteDoctorCmd(),
+		newSuiteSelfTestCmd(),
+		newSuiteEvidenceCmd(),
 		newBootstrapCmd(),
 		newVocabCmd(),
 		newBindingsCmd(),
 		newK8sCmd(),
 		newControlNodeCmd(),
 		newA2ACmd(),
+		newDevtoolsCmd(),
+		newLabCmd(),
+		newSourceOSCmd(),
+		newHolmesCmd(),
+		newModelCmd(),
+		newGuardrailCmd(),
+		newAgentSuiteCmd(),
 		newPlaceholderCmd("ask", "Agent assist: explain or inspect without mutating state"),
 		newPlaceholderCmd("plan", "Agent assist: generate a plan over deterministic tools"),
-		newPlaceholderCmd("agent", "Agent execute façade (approval-gated scaffold)"),
 		newPlaceholderCmd("mcp", "MCP boundary façade"),
 	)
 	return root

--- a/internal/cmd/suite.go
+++ b/internal/cmd/suite.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newSuiteDoctorCmd() *cobra.Command {
+	return &cobra.Command{Use: "doctor", Short: "Check Prophet suite readiness", RunE: func(cmd *cobra.Command, args []string) error {
+		tools := []string{"sourceos-ai", "holmes", "model-router", "guardrail-fabric", "agent-registry"}
+		checks := make([]map[string]any, 0, len(tools))
+		for _, tool := range tools {
+			checks = append(checks, toolCheck(tool))
+		}
+		return emit(map[string]any{"command": "prophet doctor", "status": "ok", "checks": checks})
+	}}
+}
+
+func newSuiteVersionCmd() *cobra.Command {
+	return &cobra.Command{Use: "version", Short: "Show Prophet suite version", RunE: func(cmd *cobra.Command, args []string) error {
+		return emit(map[string]any{"command": "prophet version", "tool": "prophet", "status": "ok", "version": "0.1.0-dev"})
+	}}
+}
+
+func newSuiteSelfTestCmd() *cobra.Command {
+	return &cobra.Command{Use: "self-test", Short: "Run lightweight Prophet suite self-test", RunE: func(cmd *cobra.Command, args []string) error {
+		return emit(map[string]any{"command": "prophet self-test", "status": "ok", "checks": []string{"command-surface"}})
+	}}
+}
+
+func newSuiteEvidenceCmd() *cobra.Command {
+	return &cobra.Command{Use: "emit-evidence", Short: "Emit Prophet suite local evidence", RunE: func(cmd *cobra.Command, args []string) error {
+		return emit(map[string]any{"command": "prophet emit-evidence", "status": "ok", "repo": "SocioProphet/prophet-cli", "surface": "suite-facade"})
+	}}
+}
+
+func newDevtoolsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "devtools", Short: "SourceOS developer tools facade"}
+	profile := &cobra.Command{Use: "profile", Short: "Manage SourceOS devtools profiles"}
+	profile.AddCommand(
+		&cobra.Command{Use: "list", Short: "List devtools profiles", RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet devtools profile list", "status": "ok", "profiles": []string{"core", "build", "containers", "k8s", "ai-core", "labs", "security"}})
+		}},
+		&cobra.Command{Use: "apply <profiles>", Short: "Apply devtools profiles", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet devtools profile apply", "status": "not-yet-wired", "profiles": strings.Split(args[0], ","), "delegate": "sourceos-devtools"})
+		}},
+		&cobra.Command{Use: "current", Short: "Show current devtools profiles", RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet devtools profile current", "status": "not-yet-wired", "delegate": "sourceos-devtools"})
+		}},
+	)
+	cmd.AddCommand(profile)
+	cmd.AddCommand(
+		&cobra.Command{Use: "doctor", Short: "Check devtools readiness", RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet devtools doctor", "status": "not-yet-wired", "delegate": "sourceos-devtools"})
+		}},
+		&cobra.Command{Use: "emit-evidence", Short: "Emit devtools evidence", RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet devtools emit-evidence", "status": "not-yet-wired", "delegate": "sourceos-devtools"})
+		}},
+	)
+	return cmd
+}
+
+func newLabCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "lab", Short: "Functional ML lab facade"}
+	labs := []string{"nlplab", "translationlab", "embeddinglab", "speechlab", "ocrlab", "imagelab", "videolab", "timeserieslab", "graphlab"}
+	cmd.AddCommand(
+		&cobra.Command{Use: "list", Short: "List functional labs", RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet lab list", "status": "ok", "labs": labs})
+		}},
+		&cobra.Command{Use: "enable <labs...>", Short: "Enable functional labs", Args: cobra.MinimumNArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet lab enable", "status": "not-yet-wired", "labs": args, "delegate": "sourceos-devtools"})
+		}},
+		&cobra.Command{Use: "disable <labs...>", Short: "Disable functional labs", Args: cobra.MinimumNArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet lab disable", "status": "not-yet-wired", "labs": args, "delegate": "sourceos-devtools"})
+		}},
+		&cobra.Command{Use: "status", Short: "Show lab status", RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet lab status", "status": "not-yet-wired", "delegate": "sourceos-devtools"})
+		}},
+		&cobra.Command{Use: "doctor", Short: "Check lab readiness", RunE: func(cmd *cobra.Command, args []string) error {
+			return emit(map[string]any{"command": "prophet lab doctor", "status": "not-yet-wired", "delegate": "sourceos-devtools"})
+		}},
+	)
+	return cmd
+}
+
+func newSourceOSCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "sourceos", Short: "SourceOS installer and carry facade"}
+	installCmd := &cobra.Command{Use: "install", Short: "Run SourceOS install facade", RunE: func(cmd *cobra.Command, args []string) error {
+		target, _ := cmd.Flags().GetString("target")
+		channel, _ := cmd.Flags().GetString("channel")
+		return emit(map[string]any{"command": "prophet sourceos install", "status": "not-yet-wired", "target": target, "channel": channel, "delegate": "sourceos-installer"})
+	}}
+	installCmd.Flags().String("target", "", "target platform")
+	installCmd.Flags().String("channel", "dev", "release channel")
+	carry := &cobra.Command{Use: "carry", Short: "SourceOS AI carry facade"}
+	carry.AddCommand(
+		delegateCommand("list", "List SourceOS carry refs", "sourceos-ai", []string{"carry", "list"}),
+		delegateCommand("validate", "Validate SourceOS carry refs", "sourceos-ai", []string{"carry", "validate"}),
+		delegateCommand("doctor", "Check SourceOS carry readiness", "sourceos-ai", []string{"carry", "doctor"}),
+		delegateCommand("emit-evidence", "Emit SourceOS carry evidence", "sourceos-ai", []string{"emit-evidence"}),
+	)
+	cmd.AddCommand(installCmd, carry)
+	return cmd
+}
+
+func newHolmesCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "holmes", Short: "Holmes language intelligence facade"}
+	cmd.AddCommand(
+		delegateArgsCommand("analyze <path>", "Analyze a document", "holmes", []string{"analyze"}, cobra.ExactArgs(1)),
+		delegateArgsCommand("search <query>", "Search with Holmes/Sherlock", "holmes", []string{"search"}, cobra.MinimumNArgs(1)),
+		delegateArgsCommand("graph <path>", "Build semantic graph", "holmes", []string{"graph"}, cobra.ExactArgs(1)),
+		delegateArgsCommand("govern <path>", "Evaluate language governance", "holmes", []string{"govern"}, cobra.ExactArgs(1)),
+	)
+	return cmd
+}
+
+func newModelCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "model", Short: "Model routing facade"}
+	route := &cobra.Command{Use: "route", Short: "Route a model/service request", RunE: func(cmd *cobra.Command, args []string) error {
+		task, _ := cmd.Flags().GetString("task")
+		privacy, _ := cmd.Flags().GetString("privacy")
+		return delegateOrReport("model-router", []string{"route", "--task", task, "--privacy", privacy}, "prophet model route")
+	}}
+	route.Flags().String("task", "", "task name")
+	route.Flags().String("privacy", "standard", "privacy policy")
+	cmd.AddCommand(route)
+	return cmd
+}
+
+func newGuardrailCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "guardrail", Short: "Guardrail fabric facade"}
+	cmd.AddCommand(delegateArgsCommand("test <policy.json> <input.json>", "Test guardrail policy", "guardrail-fabric", []string{"test"}, cobra.ExactArgs(2)))
+	return cmd
+}
+
+func newAgentSuiteCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "agent", Short: "Agent registry and execution facade"}
+	registry := &cobra.Command{Use: "registry", Short: "Agent registry facade"}
+	registry.AddCommand(delegateCommand("list", "List agent registry entries", "agent-registry", []string{"list"}))
+	cmd.AddCommand(registry)
+	return cmd
+}
+
+func delegateCommand(use, short, tool string, baseArgs []string) *cobra.Command {
+	return &cobra.Command{Use: use, Short: short, RunE: func(cmd *cobra.Command, args []string) error {
+		return delegateOrReport(tool, append(baseArgs, args...), "prophet "+cmd.CommandPath())
+	}}
+}
+
+func delegateArgsCommand(use, short, tool string, baseArgs []string, argRule cobra.PositionalArgs) *cobra.Command {
+	return &cobra.Command{Use: use, Short: short, Args: argRule, RunE: func(cmd *cobra.Command, args []string) error {
+		return delegateOrReport(tool, append(baseArgs, args...), "prophet "+cmd.CommandPath())
+	}}
+}
+
+func delegateOrReport(tool string, args []string, command string) error {
+	path, err := exec.LookPath(tool)
+	if err != nil {
+		return emit(map[string]any{"command": command, "status": "not-yet-wired", "delegate": tool, "reason": "delegate tool not found"})
+	}
+	run := exec.Command(path, args...)
+	var stdout, stderr bytes.Buffer
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+	if err := run.Run(); err != nil {
+		return emit(map[string]any{"command": command, "status": "failed", "delegate": tool, "stdout": stdout.String(), "stderr": stderr.String(), "error": err.Error()})
+	}
+	if strings.TrimSpace(stderr.String()) != "" {
+		return emit(map[string]any{"command": command, "status": "ok", "delegate": tool, "stdout": stdout.String(), "stderr": stderr.String()})
+	}
+	if strings.TrimSpace(stdout.String()) == "" {
+		return emit(map[string]any{"command": command, "status": "ok", "delegate": tool})
+	}
+	_, err = cmdOutput(stdout.String())
+	return err
+}
+
+func cmdOutput(s string) (int, error) {
+	if strings.TrimSpace(s) == "" {
+		return 0, nil
+	}
+	_, err := strings.NewReader(s).WriteTo(outputWriter{})
+	return len(s), err
+}
+
+type outputWriter struct{}
+
+func (outputWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return 0, errors.New("direct delegate output writer unavailable")
+}
+
+func toolCheck(tool string) map[string]any {
+	path, err := exec.LookPath(tool)
+	if err != nil {
+		return map[string]any{"tool": tool, "status": "missing"}
+	}
+	return map[string]any{"tool": tool, "status": "present", "path": path}
+}

--- a/internal/cmd/suite.go
+++ b/internal/cmd/suite.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -169,31 +169,7 @@ func delegateOrReport(tool string, args []string, command string) error {
 	if err := run.Run(); err != nil {
 		return emit(map[string]any{"command": command, "status": "failed", "delegate": tool, "stdout": stdout.String(), "stderr": stderr.String(), "error": err.Error()})
 	}
-	if strings.TrimSpace(stderr.String()) != "" {
-		return emit(map[string]any{"command": command, "status": "ok", "delegate": tool, "stdout": stdout.String(), "stderr": stderr.String()})
-	}
-	if strings.TrimSpace(stdout.String()) == "" {
-		return emit(map[string]any{"command": command, "status": "ok", "delegate": tool})
-	}
-	_, err = cmdOutput(stdout.String())
-	return err
-}
-
-func cmdOutput(s string) (int, error) {
-	if strings.TrimSpace(s) == "" {
-		return 0, nil
-	}
-	_, err := strings.NewReader(s).WriteTo(outputWriter{})
-	return len(s), err
-}
-
-type outputWriter struct{}
-
-func (outputWriter) Write(p []byte) (int, error) {
-	if len(p) == 0 {
-		return 0, nil
-	}
-	return 0, errors.New("direct delegate output writer unavailable")
+	return emit(map[string]any{"command": command, "status": "ok", "delegate": tool, "stdout": stdout.String(), "stderr": stderr.String()})
 }
 
 func toolCheck(tool string) map[string]any {
@@ -202,4 +178,11 @@ func toolCheck(tool string) map[string]any {
 		return map[string]any{"tool": tool, "status": "missing"}
 	}
 	return map[string]any{"tool": tool, "status": "present", "path": path}
+}
+
+func commandRequiredFlag(name string, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("missing required --%s", name)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Implements the first product-suite command facade in `prophet-cli`.

This PR adds:

- suite command surface documentation
- global suite commands: `version`, `doctor`, `self-test`, `emit-evidence`
- SourceOS carry facade: `prophet sourceos carry ...`
- SourceOS install placeholder with explicit `not-yet-wired` status
- devtools profile and lab selection facades
- Holmes facade commands delegated to `holmes`
- model routing, guardrail, and agent registry facades
- Makefile build/test/validate/dist/release-dry-run targets
- GitHub Actions validation workflow

## Product rule

Delegated tools return explicit `not-yet-wired` when missing. The facade must not fake success for tools that are not installed or not implemented yet.

## Validation

CI should run:

```bash
make validate
make release-dry-run
```

## Agent lane

This PR is part of the first-wave product-suite implementation after `sourceos-ai` and `holmes` landed. Codex should review for cross-repo consistency; Copilot should be used for bounded follow-up fixes/tests only.

Closes #31
