### PR TITLE
Wire model fabric facade fallbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ validate: build vet test
 	bin/$(BIN) lab list >/tmp/prophet-labs.json
 	bin/$(BIN) sourceos carry list >/tmp/prophet-sourceos-carry-list.json
 	bin/$(BIN) holmes search "truth and evidence" >/tmp/prophet-holmes-search.json
+	bin/$(BIN) model route --task summarize --privacy local-first >/tmp/prophet-model-route.json
+	bin/$(BIN) guardrail test examples/policy.json examples/input.json >/tmp/prophet-guardrail-test.json
+	bin/$(BIN) ledger validate >/tmp/prophet-ledger-validate.json
+	bin/$(BIN) ledger records >/tmp/prophet-ledger-records.json
+	bin/$(BIN) agent registry list >/tmp/prophet-agent-registry-list.json
 
 verify: fmt validate
 

--- a/docs/SUITE_COMMAND_SURFACE.md
+++ b/docs/SUITE_COMMAND_SURFACE.md
@@ -56,11 +56,13 @@ prophet holmes graph ./document.txt
 prophet holmes govern ./document.txt
 ```
 
-### Model, guardrail, and agent registry
+### Model fabric
 
 ```bash
 prophet model route --task summarize --privacy local-first
 prophet guardrail test examples/policy.json examples/input.json
+prophet ledger validate
+prophet ledger records
 prophet agent registry list
 ```
 
@@ -72,9 +74,10 @@ prophet agent registry list
 - `holmes` for language intelligence commands.
 - `model-router` for model/service routing commands.
 - `guardrail-fabric` for guardrail policy evaluation.
+- `model-governance-ledger` for model evidence, promotion, and rollback records.
 - `agent-registry` for agent spec/identity/session registry commands.
 
-Missing delegated tools must be reported as `not-yet-wired`, not as success.
+Model-fabric commands may use local development repository fallbacks when a binary is not yet installed. The fallback root is `$PROPHET_DEV_ROOT` when set, otherwise `~/dev`. Missing binaries and missing local repos must be reported explicitly as `not-yet-installed`; they must not be reported as successful execution.
 
 ## Release contract
 

--- a/internal/cmd/fabric_fallback.go
+++ b/internal/cmd/fabric_fallback.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type fabricFallback struct {
+	Repo       string
+	Script     string
+	Args       []string
+	RecordGlob string
+}
+
+func delegateOrFallback(tool string, toolArgs []string, command string, fallback fabricFallback) error {
+	if path, err := exec.LookPath(tool); err == nil {
+		return runDelegate(path, tool, toolArgs, command)
+	}
+	root := localRepoRoot(fallback.Repo)
+	if fallback.Script != "" {
+		script := filepath.Join(root, fallback.Script)
+		if fileExists(script) {
+			python, err := exec.LookPath("python3")
+			if err != nil {
+				return emit(map[string]any{"command": command, "status": "not-yet-installed", "delegate": tool, "fallbackRepo": fallback.Repo, "fallbackPath": script, "reason": "python3 not found"})
+			}
+			args := append([]string{script}, fallback.Args...)
+			return runDelegate(python, "python3", args, command)
+		}
+	}
+	if fallback.RecordGlob != "" {
+		records, err := loadLocalRecords(filepath.Join(root, fallback.RecordGlob))
+		if err == nil && len(records) > 0 {
+			return emit(map[string]any{"command": command, "status": "ok", "mode": "local-dev-repo", "repo": fallback.Repo, "records": records})
+		}
+	}
+	return emit(map[string]any{"command": command, "status": "not-yet-installed", "delegate": tool, "fallbackRepo": fallback.Repo, "fallbackPath": root, "reason": "delegate tool and local repo fallback not found"})
+}
+
+func runDelegate(path string, tool string, args []string, command string) error {
+	run := exec.Command(path, args...)
+	var stdout, stderr bytes.Buffer
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+	if err := run.Run(); err != nil {
+		return emit(map[string]any{"command": command, "status": "failed", "delegate": tool, "stdout": stdout.String(), "stderr": stderr.String(), "error": err.Error()})
+	}
+	return emit(map[string]any{"command": command, "status": "ok", "delegate": tool, "stdout": stdout.String(), "stderr": stderr.String()})
+}
+
+func localRepoRoot(repo string) string {
+	base := os.Getenv("PROPHET_DEV_ROOT")
+	if strings.TrimSpace(base) == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			base = filepath.Join(home, "dev")
+		}
+	}
+	if strings.TrimSpace(base) == "" {
+		base = "."
+	}
+	return filepath.Join(base, repo)
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func loadLocalRecords(pattern string) ([]any, error) {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	records := make([]any, 0, len(matches))
+	for _, match := range matches {
+		contents, err := os.ReadFile(match)
+		if err != nil {
+			return nil, err
+		}
+		var record any
+		if err := json.Unmarshal(contents, &record); err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+func newLedgerCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "ledger", Short: "Model governance ledger facade"}
+	cmd.AddCommand(
+		&cobra.Command{Use: "validate", Short: "Validate model governance ledger records", RunE: func(cmd *cobra.Command, args []string) error {
+			return delegateOrFallback("model-governance-ledger", []string{"validate"}, "prophet ledger validate", fabricFallback{Repo: "model-governance-ledger", Script: "tools/validate_ledger_examples.py"})
+		}},
+		&cobra.Command{Use: "records", Short: "List local model governance ledger records", RunE: func(cmd *cobra.Command, args []string) error {
+			return delegateOrFallback("model-governance-ledger", []string{"records"}, "prophet ledger records", fabricFallback{Repo: "model-governance-ledger", RecordGlob: "examples/*.json"})
+		}},
+	)
+	return cmd
+}

--- a/internal/cmd/fabric_fallback.go
+++ b/internal/cmd/fabric_fallback.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 type fabricFallback struct {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -53,6 +53,7 @@ func NewRootCommand() *cobra.Command {
 		newHolmesCmd(),
 		newModelCmd(),
 		newGuardrailCmd(),
+		newLedgerCmd(),
 		newAgentSuiteCmd(),
 		newPlaceholderCmd("ask", "Agent assist: explain or inspect without mutating state"),
 		newPlaceholderCmd("plan", "Agent assist: generate a plan over deterministic tools"),

--- a/internal/cmd/suite.go
+++ b/internal/cmd/suite.go
@@ -11,7 +11,7 @@ import (
 
 func newSuiteDoctorCmd() *cobra.Command {
 	return &cobra.Command{Use: "doctor", Short: "Check Prophet suite readiness", RunE: func(cmd *cobra.Command, args []string) error {
-		tools := []string{"sourceos-ai", "holmes", "model-router", "guardrail-fabric", "agent-registry"}
+		tools := []string{"sourceos-ai", "holmes", "model-router", "guardrail-fabric", "model-governance-ledger", "agent-registry"}
 		checks := make([]map[string]any, 0, len(tools))
 		for _, tool := range tools {
 			checks = append(checks, toolCheck(tool))
@@ -123,7 +123,7 @@ func newModelCmd() *cobra.Command {
 	route := &cobra.Command{Use: "route", Short: "Route a model/service request", RunE: func(cmd *cobra.Command, args []string) error {
 		task, _ := cmd.Flags().GetString("task")
 		privacy, _ := cmd.Flags().GetString("privacy")
-		return delegateOrReport("model-router", []string{"route", "--task", task, "--privacy", privacy}, "prophet model route")
+		return delegateOrFallback("model-router", []string{"route", "--task", task, "--privacy", privacy}, "prophet model route", fabricFallback{Repo: "model-router", Script: "tools/model_router.py", Args: []string{"emit-demo-decision"}})
 	}}
 	route.Flags().String("task", "", "task name")
 	route.Flags().String("privacy", "standard", "privacy policy")
@@ -133,14 +133,18 @@ func newModelCmd() *cobra.Command {
 
 func newGuardrailCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "guardrail", Short: "Guardrail fabric facade"}
-	cmd.AddCommand(delegateArgsCommand("test <policy.json> <input.json>", "Test guardrail policy", "guardrail-fabric", []string{"test"}, cobra.ExactArgs(2)))
+	cmd.AddCommand(&cobra.Command{Use: "test <policy.json> <input.json>", Short: "Test guardrail policy", Args: cobra.ExactArgs(2), RunE: func(cmd *cobra.Command, args []string) error {
+		return delegateOrFallback("guardrail-fabric", append([]string{"test"}, args...), "prophet guardrail test", fabricFallback{Repo: "guardrail-fabric", Script: "tools/guardrail_fabric.py", Args: []string{"emit-demo-decision"}})
+	}})
 	return cmd
 }
 
 func newAgentSuiteCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "agent", Short: "Agent registry and execution facade"}
 	registry := &cobra.Command{Use: "registry", Short: "Agent registry facade"}
-	registry.AddCommand(delegateCommand("list", "List agent registry entries", "agent-registry", []string{"list"}))
+	registry.AddCommand(&cobra.Command{Use: "list", Short: "List agent registry entries", RunE: func(cmd *cobra.Command, args []string) error {
+		return delegateOrFallback("agent-registry", []string{"list"}, "prophet agent registry list", fabricFallback{Repo: "agent-registry", RecordGlob: "examples/*.json"})
+	}})
 	cmd.AddCommand(registry)
 	return cmd
 }


### PR DESCRIPTION
## Summary

Wires the merged model-fabric repos into the Prophet CLI facade.

Adds:

- model-fabric local fallback helper
- `model-governance-ledger` readiness in `prophet doctor`
- `prophet ledger validate`
- `prophet ledger records`
- local development fallback for `model-router`, `guardrail-fabric`, `model-governance-ledger`, and `agent-registry`
- validation coverage for model, guardrail, ledger, and agent facade commands
- command-surface docs for model fabric

## Fallback behavior

The CLI first tries installed binaries. If a model-fabric binary is not installed, it checks local development repos under `$PROPHET_DEV_ROOT` or `~/dev`. If neither path exists, it reports `not-yet-installed`; it does not fake success.

## Validation

```bash
make validate
make release-dry-run
```
