### PR TITLE
Expose query routing dry-run command surface

### DIFF
--- a/.github/workflows/lattice-studio-commands.yml
+++ b/.github/workflows/lattice-studio-commands.yml
@@ -30,3 +30,4 @@ jobs:
           bash -n scripts/lattice-safe-plan.sh
           bash -n scripts/lattice-approve.sh
           bash -n scripts/lattice-query.sh
+          bash -n scripts/lattice-route.sh

--- a/manifests/lattice-studio-commands.json
+++ b/manifests/lattice-studio-commands.json
@@ -3,7 +3,7 @@
   "kind": "ProphetCliCommandSurface",
   "metadata": {
     "name": "lattice-studio",
-    "version": "0.6.0"
+    "version": "0.7.0"
   },
   "delegatesTo": {
     "repo": "SocioProphet/prophet-platform",
@@ -29,7 +29,8 @@
     "lattice-place",
     "lattice-safe-plan",
     "lattice-approve",
-    "lattice-query"
+    "lattice-query",
+    "lattice-route"
   ],
   "surfaces": [
     "lattice-studio",
@@ -51,6 +52,7 @@
     "placement-decision",
     "safe-placement-execution",
     "execution-approval",
-    "federated-query"
+    "federated-query",
+    "query-routing-dry-run"
   ]
 }

--- a/scripts/lattice-route.sh
+++ b/scripts/lattice-route.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${PROPHET_PLATFORM_DIR:-$HOME/dev/prophet-platform}"
+STUDIO_SRC="$ROOT_DIR/apps/lattice-studio/src"
+
+if [[ ! -d "$STUDIO_SRC" ]]; then
+  echo "prophet-cli: missing Lattice Studio source at $STUDIO_SRC" >&2
+  echo "Set PROPHET_PLATFORM_DIR or clone SocioProphet/prophet-platform under ~/dev." >&2
+  exit 2
+fi
+
+export PYTHONPATH="$STUDIO_SRC${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m lattice_studio.query_planner_cli "$@"

--- a/scripts/validate_lattice_studio_commands.py
+++ b/scripts/validate_lattice_studio_commands.py
@@ -27,6 +27,7 @@ REQUIRED_COMMANDS = {
     "lattice-safe-plan",
     "lattice-approve",
     "lattice-query",
+    "lattice-route",
 }
 REQUIRED_SURFACES = {
     "byoc",
@@ -38,6 +39,7 @@ REQUIRED_SURFACES = {
     "safe-placement-execution",
     "execution-approval",
     "federated-query",
+    "query-routing-dry-run",
 }
 
 


### PR DESCRIPTION
Adds the lattice-route facade for Lattice Studio QueryRoutingDryRunPlan output. Updates command manifest, validator, and CI syntax checks. Depends on prophet-platform PR 260, which has merged.