### PR TITLE
Add SourceOS Agent Machine and Office facade delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,52 @@
 # prophet-cli
 
 Façade repo for Prophet command surface and SourceOS bootstrap delegation.
+
+`prophet` is the stable operator-facing command. It does not duplicate implementation logic that belongs in SourceOS or AgentTerm repositories.
+
+## Delegation model
+
+| Prophet command | Delegate | Owning repo |
+|---|---|---|
+| `prophet sourceos agent-machine ...` | `sourceosctl agent-machine ...` | `SourceOS-Linux/sourceos-devtools` |
+| `prophet sourceos office ...` | `sourceosctl office ...` | `SourceOS-Linux/sourceos-devtools` |
+| `prophet sourceos agent-term ...` | `agent-term ...` | `SourceOS-Linux/agent-term` |
+
+## Examples
+
+```bash
+prophet sourceos agent-machine mounts plan
+prophet sourceos agent-machine mounts init --dry-run
+prophet sourceos office doctor
+prophet sourceos office plan --artifact-type slide-deck --format pptx --title "Demo Deck"
+prophet sourceos office generate --dry-run --artifact-type document --format docx --title "Demo Report"
+prophet sourceos office convert ./example.docx --to pdf --dry-run
+prophet sourceos agent-term office create-deck '!prophet-workspace' --workroom workroom-demo-0001 --title 'Demo Briefing Deck'
+```
+
+## Install path
+
+The intended Mac-first install path is:
+
+```bash
+brew tap SocioProphet/prophet
+brew install prophet-cli
+brew install sourceos-devtools
+brew install agent-term
+```
+
+`prophet-cli` only provides the `prophet` facade. The delegated binaries must also be installed or available on `PATH`.
+
+## Boundary
+
+This repo does not own:
+
+- Agent Machine implementation;
+- Office generation/conversion engines;
+- LibreOffice, Collabora, ONLYOFFICE, Microsoft Graph, or Google Workspace adapters;
+- AgentTerm event log semantics;
+- AgentPlane evidence contracts;
+- Agent Registry grants;
+- Homebrew formulae.
+
+Those remain in their owning repositories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prophet-cli"
+version = "0.1.0"
+description = "Prophet facade command surface for SocioProphet and SourceOS local tools."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [
+  { name = "SocioProphet" }
+]
+keywords = ["socioprophet", "sourceos", "prophet", "cli", "agent-machine", "office"]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12"
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "ruff>=0.4"
+]
+
+[project.scripts]
+prophet = "prophet_cli.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+line-length = 100
+src = ["src", "tests"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/prophet_cli/__init__.py
+++ b/src/prophet_cli/__init__.py
@@ -1,0 +1,3 @@
+"""Prophet CLI facade package."""
+
+__version__ = "0.1.0"

--- a/src/prophet_cli/cli.py
+++ b/src/prophet_cli/cli.py
@@ -1,0 +1,76 @@
+"""Prophet facade CLI.
+
+The `prophet` command is a stable operator-facing facade. It delegates local
+SourceOS implementation work to the owning CLIs instead of duplicating engine
+logic here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from typing import Sequence
+
+from prophet_cli import __version__
+
+
+DELEGATES = {
+    "sourceosctl": "Install sourceos-devtools from SocioProphet/homebrew-prophet or run it from SourceOS-Linux/sourceos-devtools.",
+    "agent-term": "Install agent-term from SocioProphet/homebrew-prophet or run it from SourceOS-Linux/agent-term.",
+}
+
+
+def _delegate(binary: str, args: Sequence[str]) -> int:
+    resolved = shutil.which(binary)
+    if not resolved:
+        print(f"error: required delegate not found: {binary}", file=sys.stderr)
+        print(DELEGATES.get(binary, "Install the missing delegate and retry."), file=sys.stderr)
+        return 127
+    completed = subprocess.run([resolved, *args], check=False)
+    return int(completed.returncode)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="prophet",
+        description="Prophet facade command surface for SocioProphet and SourceOS tools.",
+    )
+    parser.add_argument("--version", action="version", version=f"prophet {__version__}")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sourceos = sub.add_parser("sourceos", help="Delegate SourceOS local workflows")
+    sourceos_sub = sourceos.add_subparsers(dest="sourceos_command", required=True)
+
+    agent_machine = sourceos_sub.add_parser("agent-machine", help="Delegate SourceOS Agent Machine commands")
+    agent_machine.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to sourceosctl agent-machine")
+
+    office = sourceos_sub.add_parser("office", help="Delegate SourceOS Office Plane commands")
+    office.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to sourceosctl office")
+
+    agent_term = sourceos_sub.add_parser("agent-term", help="Delegate AgentTerm commands")
+    agent_term.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to agent-term")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "sourceos":
+        if args.sourceos_command == "agent-machine":
+            return _delegate("sourceosctl", ["agent-machine", *args.args])
+        if args.sourceos_command == "office":
+            return _delegate("sourceosctl", ["office", *args.args])
+        if args.sourceos_command == "agent-term":
+            return _delegate("agent-term", list(args.args))
+
+    parser.error("unknown command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,75 @@
+"""Tests for the Prophet facade CLI."""
+
+from __future__ import annotations
+
+import subprocess
+
+from prophet_cli.cli import main
+
+
+class Completed:
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+
+def test_sourceos_office_delegates_to_sourceosctl(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["sourceos", "office", "doctor"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/sourceosctl", "office", "doctor"]]
+
+
+def test_sourceos_agent_machine_delegates_to_sourceosctl(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["sourceos", "agent-machine", "mounts", "plan"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/sourceosctl", "agent-machine", "mounts", "plan"]]
+
+
+def test_sourceos_agent_term_delegates_to_agent_term(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["sourceos", "agent-term", "office", "inspect", "!prophet-workspace", "/tmp/demo.pptx"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/agent-term", "office", "inspect", "!prophet-workspace", "/tmp/demo.pptx"]]
+
+
+def test_missing_delegate_returns_127(monkeypatch, capsys):
+    monkeypatch.setattr("shutil.which", lambda binary: None)
+
+    rc = main(["sourceos", "office", "doctor"])
+
+    captured = capsys.readouterr()
+    assert rc == 127
+    assert "required delegate not found: sourceosctl" in captured.err
+    assert "sourceos-devtools" in captured.err


### PR DESCRIPTION
## Summary

Turns `prophet-cli` into a minimal installable Python facade that delegates SourceOS Agent Machine, Office Plane, and AgentTerm commands to their owning CLIs.

The facade remains intentionally thin:

```text
prophet sourceos agent-machine ... -> sourceosctl agent-machine ...
prophet sourceos office ...        -> sourceosctl office ...
prophet sourceos agent-term ...    -> agent-term ...
```

## Changes

- Adds `pyproject.toml` with a `prophet` console script.
- Adds `src/prophet_cli/cli.py` facade router.
- Adds tests for:
  - `sourceos office` delegation;
  - `sourceos agent-machine` delegation;
  - `sourceos agent-term` delegation;
  - missing delegate error behavior.
- Updates README with install path, examples, and repo boundaries.

## Boundary

This repo does not own SourceOS Agent Machine implementation, Office generation/conversion engines, AgentTerm event log semantics, AgentPlane evidence contracts, Agent Registry grants, or Homebrew formulae.

## Validation

Expected local validation:

```bash
pip install -e '.[dev]'
pytest
ruff check src tests
```