### PR TITLE
Add Local Model Door facade delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Façade repo for Prophet command surface and SourceOS bootstrap delegation.
 
 | Prophet command | Delegate | Owning repo |
 |---|---|---|
+| `prophet sourceos local-model ...` | `sourceosctl local-model ...` | `SourceOS-Linux/sourceos-devtools` |
 | `prophet sourceos agent-machine ...` | `sourceosctl agent-machine ...` | `SourceOS-Linux/sourceos-devtools` |
 | `prophet sourceos office ...` | `sourceosctl office ...` | `SourceOS-Linux/sourceos-devtools` |
 | `prophet sourceos agent-term ...` | `agent-term ...` | `SourceOS-Linux/agent-term` |
@@ -15,6 +16,10 @@ Façade repo for Prophet command surface and SourceOS bootstrap delegation.
 ## Examples
 
 ```bash
+prophet sourceos local-model doctor
+prophet sourceos local-model profiles
+prophet sourceos local-model plan --profile local-llama32-1b
+prophet sourceos local-model route --task-class office-assist
 prophet sourceos agent-machine mounts plan
 prophet sourceos agent-machine mounts init --dry-run
 prophet sourceos office doctor
@@ -41,6 +46,9 @@ brew install agent-term
 
 This repo does not own:
 
+- Local Model Door runtime logic;
+- model weights, model downloads, or inference;
+- personal tuning or personalization governance;
 - Agent Machine implementation;
 - Office generation/conversion engines;
 - LibreOffice, Collabora, ONLYOFFICE, Microsoft Graph, or Google Workspace adapters;

--- a/src/prophet_cli/cli.py
+++ b/src/prophet_cli/cli.py
@@ -44,6 +44,9 @@ def build_parser() -> argparse.ArgumentParser:
     sourceos = sub.add_parser("sourceos", help="Delegate SourceOS local workflows")
     sourceos_sub = sourceos.add_subparsers(dest="sourceos_command", required=True)
 
+    local_model = sourceos_sub.add_parser("local-model", help="Delegate SourceOS Local Model Door commands")
+    local_model.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to sourceosctl local-model")
+
     agent_machine = sourceos_sub.add_parser("agent-machine", help="Delegate SourceOS Agent Machine commands")
     agent_machine.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to sourceosctl agent-machine")
 
@@ -61,6 +64,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "sourceos":
+        if args.sourceos_command == "local-model":
+            return _delegate("sourceosctl", ["local-model", *args.args])
         if args.sourceos_command == "agent-machine":
             return _delegate("sourceosctl", ["agent-machine", *args.args])
         if args.sourceos_command == "office":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,24 @@ class Completed:
         self.returncode = returncode
 
 
+def test_sourceos_local_model_delegates_to_sourceosctl(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["sourceos", "local-model", "doctor"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/sourceosctl", "local-model", "doctor"]]
+
+
 def test_sourceos_office_delegates_to_sourceosctl(monkeypatch):
     calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary

Adds `prophet sourceos local-model ...` delegation to the existing Prophet facade.

## Changes

- Adds `prophet sourceos local-model ... -> sourceosctl local-model ...`.
- Adds delegation test coverage.
- Updates README examples and boundary language.

## Safety posture

This remains a thin facade. It does not own local model runtime logic, model downloads, model calls, personalization governance, Agent Machine implementation, Office execution, AgentTerm semantics, or Homebrew formulae.

## Validation

Expected repo validation:

```bash
pytest
ruff check src tests
```