### PR TITLE
Add Network and Native Assistant facade delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Façade repo for Prophet command surface and SourceOS bootstrap delegation.
 | Prophet command | Delegate | Owning repo |
 |---|---|---|
 | `prophet sourceos local-model ...` | `sourceosctl local-model ...` | `SourceOS-Linux/sourceos-devtools` |
+| `prophet sourceos network ...` | `sourceosctl network ...` | `SourceOS-Linux/sourceos-devtools` |
+| `prophet sourceos native-assistant ...` | `sourceosctl native-assistant ...` | `SourceOS-Linux/sourceos-devtools` |
 | `prophet sourceos agent-machine ...` | `sourceosctl agent-machine ...` | `SourceOS-Linux/sourceos-devtools` |
 | `prophet sourceos office ...` | `sourceosctl office ...` | `SourceOS-Linux/sourceos-devtools` |
 | `prophet sourceos agent-term ...` | `agent-term ...` | `SourceOS-Linux/agent-term` |
@@ -20,6 +22,11 @@ prophet sourceos local-model doctor
 prophet sourceos local-model profiles
 prophet sourceos local-model plan --profile local-llama32-1b
 prophet sourceos local-model route --task-class office-assist
+prophet sourceos network doctor
+prophet sourceos network plan --enterprise --mesh --allow-listed --destination models.enterprise.example
+prophet sourceos network provider --provider-class openai-compatible --owner user
+prophet sourceos native-assistant plan --operation open-workroom
+prophet sourceos native-assistant plan --operation create-office-artifact
 prophet sourceos agent-machine mounts plan
 prophet sourceos agent-machine mounts init --dry-run
 prophet sourceos office doctor
@@ -47,6 +54,9 @@ brew install agent-term
 This repo does not own:
 
 - Local Model Door runtime logic;
+- Network Door / Firewall Door / Mesh Door implementation;
+- BYOM provider connectivity or credentials;
+- native assistant runtime adapters, Siri/App Intents/Shortcuts integration, Android intents, Windows shell APIs, browser extension transports, or MCP/native transports;
 - model weights, model downloads, or inference;
 - personal tuning or personalization governance;
 - Agent Machine implementation;

--- a/src/prophet_cli/cli.py
+++ b/src/prophet_cli/cli.py
@@ -47,6 +47,16 @@ def build_parser() -> argparse.ArgumentParser:
     local_model = sourceos_sub.add_parser("local-model", help="Delegate SourceOS Local Model Door commands")
     local_model.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to sourceosctl local-model")
 
+    network = sourceos_sub.add_parser("network", help="Delegate SourceOS Network Door commands")
+    network.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to sourceosctl network")
+
+    native_assistant = sourceos_sub.add_parser(
+        "native-assistant", help="Delegate SourceOS Native Assistant Door commands"
+    )
+    native_assistant.add_argument(
+        "args", nargs=argparse.REMAINDER, help="Arguments passed to sourceosctl native-assistant"
+    )
+
     agent_machine = sourceos_sub.add_parser("agent-machine", help="Delegate SourceOS Agent Machine commands")
     agent_machine.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to sourceosctl agent-machine")
 
@@ -66,6 +76,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "sourceos":
         if args.sourceos_command == "local-model":
             return _delegate("sourceosctl", ["local-model", *args.args])
+        if args.sourceos_command == "network":
+            return _delegate("sourceosctl", ["network", *args.args])
+        if args.sourceos_command == "native-assistant":
+            return _delegate("sourceosctl", ["native-assistant", *args.args])
         if args.sourceos_command == "agent-machine":
             return _delegate("sourceosctl", ["agent-machine", *args.args])
         if args.sourceos_command == "office":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,42 @@ def test_sourceos_local_model_delegates_to_sourceosctl(monkeypatch):
     assert calls == [["/usr/bin/sourceosctl", "local-model", "doctor"]]
 
 
+def test_sourceos_network_delegates_to_sourceosctl(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["sourceos", "network", "doctor"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/sourceosctl", "network", "doctor"]]
+
+
+def test_sourceos_native_assistant_delegates_to_sourceosctl(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["sourceos", "native-assistant", "plan", "--operation", "open-workroom"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/sourceosctl", "native-assistant", "plan", "--operation", "open-workroom"]]
+
+
 def test_sourceos_office_delegates_to_sourceosctl(monkeypatch):
     calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary

Adds Prophet facade delegation for the SourceOS Network Door and Native Assistant Door command surfaces.

## Changes

- Adds `prophet sourceos network ... -> sourceosctl network ...`.
- Adds `prophet sourceos native-assistant ... -> sourceosctl native-assistant ...`.
- Adds delegation tests for both command groups.
- Updates README command examples and boundary language.

## Safety posture

This remains a thin facade. It does not mutate firewall state, install service mesh components, contact BYOM providers, invoke native assistant APIs, store credentials, run model calls, or send prompts.

## Validation

Expected repo validation:

```bash
pytest
ruff check src tests
```