### PR TITLE
ci: run k8s scheduling checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
             fixtures/semantic-core/k8s/valid-deployment-service-ingress.yaml \
             fixtures/semantic-core/k8s/valid-k3s-ingress.yaml \
             fixtures/semantic-core/k8s/valid-kubeedge-deployment.yaml
+          (
+            cd socioprophet-standards-knowledge
+            python3 k8s/tools/check_scheduling.py --manifest fixtures/semantic-core/k8s/valid-kubeedge-toleration.yaml --json
+          )
 
   k8s-policy-samples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds runtime CI coverage for the standards-side K8s scheduling checker.

### Changed
- extends the existing `k8s-shapecheck` workflow job
- runs `k8s/tools/check_scheduling.py` against the positive KubeEdge toleration fixture
- relies on the existing `k8s-policy-samples` job to auto-discover invalid K8s fixtures from the standards repo

## Why

`socioprophet-standards-knowledge` now includes the first taints/tolerations scheduling policy slice. Runtime CI should exercise the positive scheduling fixture so `prophet-cli` continues tracking the standards contract.

## Scope

CI-only. No command behavior changes.
