### PR TITLE
ci: check k8s scheduling rejection sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,13 @@ jobs:
           (
             cd socioprophet-standards-knowledge
             python3 k8s/tools/check_scheduling.py --manifest fixtures/semantic-core/k8s/valid-kubeedge-toleration.yaml --json
+            set +e
+            python3 k8s/tools/check_scheduling.py --manifest fixtures/semantic-core/k8s/invalid-kubeedge-missing-toleration.yaml --json
+            code=$?
+            set -e
+            if [ "$code" -eq 0 ]; then
+              exit 1
+            fi
           )
 
   k8s-policy-samples:


### PR DESCRIPTION
## Summary

Adds explicit runtime CI coverage for the standards-side K8s scheduling rejection sample.

### Changed
- extends the existing `k8s-shapecheck` workflow job
- runs `k8s/tools/check_scheduling.py` against the positive KubeEdge toleration fixture
- runs the same checker against the missing-toleration fixture and asserts a non-zero exit

## Why

The standards repo now contains a focused scheduling checker and positive/negative KubeEdge toleration fixtures. Runtime CI should explicitly exercise both sides of that contract.

## Scope

CI-only. No command behavior changes.
