### PR TITLE
fix(control-node): fail closed on processor errors

### DIFF
--- a/internal/controlnode/controlnode.go
+++ b/internal/controlnode/controlnode.go
@@ -2,6 +2,7 @@ package controlnode
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,14 @@ type ExecResult struct {
 	ExitCode int           `json:"exit_code"`
 	Duration time.Duration `json:"duration_ns"`
 	WorkDir  string        `json:"work_dir,omitempty"`
+}
+
+type ProcessError struct {
+	Probe ExecResult
+}
+
+func (e ProcessError) Error() string {
+	return fmt.Sprintf("control-node processor failed with exit code %d", e.Probe.ExitCode)
 }
 
 func repoPath() string {
@@ -42,6 +51,7 @@ func runInDir(ctx context.Context, dir string, argv []string) (ExecResult, error
 			res.ExitCode = ee.ExitCode()
 		} else {
 			res.Stderr = err.Error()
+			res.ExitCode = 1
 		}
 	} else if cmd.ProcessState != nil {
 		res.ExitCode = cmd.ProcessState.ExitCode()
@@ -63,14 +73,19 @@ func Status(_ context.Context) (Response, error) {
 
 func Process(ctx context.Context, inputPath, outDir string) (Response, error) {
 	argv := []string{"python3", filepath.ToSlash("scripts/process_local_control_node_input.py"), inputPath, outDir}
-	res, _ := runInDir(ctx, repoPath(), argv)
-	return Response{
+	res, err := runInDir(ctx, repoPath(), argv)
+	resp := Response{
 		"delegated_to": "SocioProphet/agentplane",
-		"status": "scaffold",
+		"status": "completed",
 		"operation": "process",
 		"input_path": inputPath,
 		"out_dir": outDir,
 		"processor": "scripts/process_local_control_node_input.py",
 		"probe": res,
-	}, nil
+	}
+	if err != nil || res.ExitCode != 0 {
+		resp["status"] = "failed"
+		return resp, ProcessError{Probe: res}
+	}
+	return resp, nil
 }

--- a/internal/controlnode/controlnode_test.go
+++ b/internal/controlnode/controlnode_test.go
@@ -2,6 +2,7 @@ package controlnode
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -15,13 +16,20 @@ func TestStatusIncludesContractsRepo(t *testing.T) {
 	}
 }
 
-func TestProcessReturnsProbeEnvelope(t *testing.T) {
+func TestProcessFailsClosedAndReturnsProbeEnvelope(t *testing.T) {
 	resp, err := Process(context.Background(), "input.json", "out")
-	if err != nil {
-		t.Fatalf("Process returned error: %v", err)
+	if err == nil {
+		t.Fatalf("expected Process to fail when processor cannot run")
+	}
+	var processErr ProcessError
+	if !errors.As(err, &processErr) {
+		t.Fatalf("expected ProcessError, got %T", err)
 	}
 	if got := resp["operation"]; got != "process" {
 		t.Fatalf("unexpected operation: %v", got)
+	}
+	if got := resp["status"]; got != "failed" {
+		t.Fatalf("expected failed status, got %v", got)
 	}
 	probe, ok := resp["probe"].(ExecResult)
 	if !ok {


### PR DESCRIPTION
Fix `prophet control-node process` so it does not silently swallow AgentPlane processor failures.

Changes:
- preserve the probe envelope for debugging
- return a typed `ProcessError` when the delegated processor fails or exits nonzero
- set response status to `failed` on processor failure
- update tests to assert fail-closed behavior

This is a focused hardening follow-up to the merged control-node façade.