### PR TITLE
Delegate AgentPlane commands to sp-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # prophet-cli
 
-Façade repo for Prophet command surface and SourceOS bootstrap delegation.
+Façade repo for Prophet command surface and SourceOS / AgentPlane bootstrap delegation.
 
-`prophet` is the stable operator-facing command. It does not duplicate implementation logic that belongs in SourceOS or AgentTerm repositories.
+`prophet` is the stable operator-facing command. It does not duplicate implementation logic that belongs in SourceOS, AgentTerm, or AgentPlane repositories.
 
 ## Delegation model
 
@@ -14,6 +14,7 @@ Façade repo for Prophet command surface and SourceOS bootstrap delegation.
 | `prophet sourceos agent-machine ...` | `sourceosctl agent-machine ...` | `SourceOS-Linux/sourceos-devtools` |
 | `prophet sourceos office ...` | `sourceosctl office ...` | `SourceOS-Linux/sourceos-devtools` |
 | `prophet sourceos agent-term ...` | `agent-term ...` | `SourceOS-Linux/agent-term` |
+| `prophet agentplane ...` | `sp-run ...` | `SocioProphet/agentplane` |
 
 ## Examples
 
@@ -34,6 +35,11 @@ prophet sourceos office plan --artifact-type slide-deck --format pptx --title "D
 prophet sourceos office generate --dry-run --artifact-type document --format docx --title "Demo Report"
 prophet sourceos office convert ./example.docx --to pdf --dry-run
 prophet sourceos agent-term office create-deck '!prophet-workspace' --workroom workroom-demo-0001 --title 'Demo Briefing Deck'
+prophet agentplane doctor
+prophet agentplane preflight ./governed-run-contract.json
+prophet agentplane admit ./governed-run-contract.json --preflight ./preflight-receipt.json --authority-state ./agent-authority-current-state.json --projected-cost-usd 0.25
+prophet agentplane dossier ./.socioprophet/runs/governed-run-alpha-001
+prophet agentplane validate-dossier ./run-dossier.json
 ```
 
 ## Install path
@@ -48,6 +54,14 @@ brew install agent-term
 ```
 
 `prophet-cli` only provides the `prophet` facade. The delegated binaries must also be installed or available on `PATH`.
+
+For AgentPlane governed-runner commands, install or expose the AgentPlane-owned `sp-run` delegate from `SocioProphet/agentplane`:
+
+```bash
+python3 -m pip install -e /path/to/agentplane
+sp-run doctor
+prophet agentplane doctor
+```
 
 ## Boundary
 
@@ -64,7 +78,10 @@ This repo does not own:
 - LibreOffice, Collabora, ONLYOFFICE, Microsoft Graph, or Google Workspace adapters;
 - AgentTerm event log semantics;
 - AgentPlane evidence contracts;
-- Agent Registry grants;
+- AgentPlane governed-runner implementation;
+- Agent Registry grants or authority state;
 - Homebrew formulae.
 
 Those remain in their owning repositories.
+
+`prophet agentplane ...` is a facade over `sp-run ...`; the implementation remains in `SocioProphet/agentplane`.

--- a/src/prophet_cli/cli.py
+++ b/src/prophet_cli/cli.py
@@ -1,8 +1,8 @@
 """Prophet facade CLI.
 
 The `prophet` command is a stable operator-facing facade. It delegates local
-SourceOS implementation work to the owning CLIs instead of duplicating engine
-logic here.
+SourceOS and AgentPlane implementation work to the owning CLIs instead of
+duplicating engine logic here.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from prophet_cli import __version__
 DELEGATES = {
     "sourceosctl": "Install sourceos-devtools from SocioProphet/homebrew-prophet or run it from SourceOS-Linux/sourceos-devtools.",
     "agent-term": "Install agent-term from SocioProphet/homebrew-prophet or run it from SourceOS-Linux/agent-term.",
+    "sp-run": "Install AgentPlane so the sp-run delegate is available on PATH, or run it from SocioProphet/agentplane.",
 }
 
 
@@ -66,6 +67,9 @@ def build_parser() -> argparse.ArgumentParser:
     agent_term = sourceos_sub.add_parser("agent-term", help="Delegate AgentTerm commands")
     agent_term.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to agent-term")
 
+    agentplane = sub.add_parser("agentplane", help="Delegate AgentPlane governed-runner commands")
+    agentplane.add_argument("args", nargs=argparse.REMAINDER, help="Arguments passed to sp-run")
+
     return parser
 
 
@@ -86,6 +90,9 @@ def main(argv: list[str] | None = None) -> int:
             return _delegate("sourceosctl", ["office", *args.args])
         if args.sourceos_command == "agent-term":
             return _delegate("agent-term", list(args.args))
+
+    if args.command == "agentplane":
+        return _delegate("sp-run", list(args.args))
 
     parser.error("unknown command")
     return 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,76 @@ def test_sourceos_agent_term_delegates_to_agent_term(monkeypatch):
     assert calls == [["/usr/bin/agent-term", "office", "inspect", "!prophet-workspace", "/tmp/demo.pptx"]]
 
 
+def test_agentplane_doctor_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["agentplane", "doctor"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/sp-run", "doctor"]]
+
+
+def test_agentplane_preflight_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["agentplane", "preflight", "contract.json"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/sp-run", "preflight", "contract.json"]]
+
+
+def test_agentplane_admit_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main([
+        "agentplane",
+        "admit",
+        "contract.json",
+        "--preflight",
+        "preflight.json",
+        "--authority-state",
+        "authority.json",
+    ])
+
+    assert rc == 0
+    assert calls == [[
+        "/usr/bin/sp-run",
+        "admit",
+        "contract.json",
+        "--preflight",
+        "preflight.json",
+        "--authority-state",
+        "authority.json",
+    ]]
+
+
 def test_missing_delegate_returns_127(monkeypatch, capsys):
     monkeypatch.setattr("shutil.which", lambda binary: None)
 
@@ -127,3 +197,14 @@ def test_missing_delegate_returns_127(monkeypatch, capsys):
     assert rc == 127
     assert "required delegate not found: sourceosctl" in captured.err
     assert "sourceos-devtools" in captured.err
+
+
+def test_missing_sp_run_delegate_returns_127(monkeypatch, capsys):
+    monkeypatch.setattr("shutil.which", lambda binary: None)
+
+    rc = main(["agentplane", "doctor"])
+
+    captured = capsys.readouterr()
+    assert rc == 127
+    assert "required delegate not found: sp-run" in captured.err
+    assert "AgentPlane" in captured.err


### PR DESCRIPTION
## Summary

Adds `prophet agentplane ...` as a pure facade delegation to the AgentPlane-owned `sp-run` command.

This preserves the implementation boundary:

- `SocioProphet/agentplane` owns governed-runner implementation and `sp-run`.
- `SocioProphet/prophet-cli` exposes the stable operator-facing facade.

## Adds

- `sp-run` delegate registration in `src/prophet_cli/cli.py`
- `prophet agentplane ...` parser branch
- tests for:
  - `prophet agentplane doctor`
  - `prophet agentplane preflight <contract>`
  - `prophet agentplane admit <contract> --preflight <preflight> --authority-state <state>`
  - missing `sp-run` delegate returns 127
- README delegation table and examples

## Commands

```bash
prophet agentplane doctor
prophet agentplane preflight ./governed-run-contract.json
prophet agentplane admit ./governed-run-contract.json --preflight ./preflight-receipt.json --authority-state ./agent-authority-current-state.json --projected-cost-usd 0.25
prophet agentplane dossier ./.socioprophet/runs/governed-run-alpha-001
prophet agentplane validate-dossier ./run-dossier.json
```

## Boundary

`prophet-cli` does not own AgentPlane evidence contracts, governed-runner implementation, Agent Registry grants, or authority state.

It delegates to `sp-run ...` exactly like existing SourceOS delegation delegates to `sourceosctl ...` and AgentTerm delegation delegates to `agent-term ...`.

## Validation

```bash
pytest -q
```