### PR TITLE
Document and test governed-runner smoke facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ prophet agentplane admit ./governed-run-contract.json --preflight ./preflight-re
 prophet agentplane dossier ./.socioprophet/runs/governed-run-alpha-001
 prophet agentplane validate-dossier ./run-dossier.json
 prophet governed-runner doctor
+prophet governed-runner smoke --output-dir ./.socioprophet/smoke/governed-runner
 prophet governed-runner preflight ./governed-run-contract.json
 prophet governed-runner admit ./governed-run-contract.json --preflight ./preflight-receipt.json --authority-state ./agent-authority-current-state.json --projected-cost-usd 0.25
 prophet governed-runner dossier ./.socioprophet/runs/governed-run-alpha-001
@@ -66,8 +67,10 @@ For AgentPlane governed-runner commands, install or expose the AgentPlane-owned 
 ```bash
 python3 -m pip install -e /path/to/agentplane
 sp-run doctor
+sp-run smoke --output-dir ./.socioprophet/smoke/governed-runner
 prophet agentplane doctor
 prophet governed-runner doctor
+prophet governed-runner smoke --output-dir ./.socioprophet/smoke/governed-runner
 ```
 
 ## Boundary

--- a/tests/test_governed_runner_smoke_facade.py
+++ b/tests/test_governed_runner_smoke_facade.py
@@ -1,0 +1,40 @@
+"""Tests for the Prophet governed-runner smoke facade."""
+
+from __future__ import annotations
+
+import subprocess
+
+from prophet_cli.cli import main
+
+
+class Completed:
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+
+def test_governed_runner_smoke_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main([
+        "governed-runner",
+        "smoke",
+        "--output-dir",
+        ".socioprophet/smoke/governed-runner",
+    ])
+
+    assert rc == 0
+    assert calls == [[
+        "/usr/bin/sp-run",
+        "smoke",
+        "--output-dir",
+        ".socioprophet/smoke/governed-runner",
+    ]]


### PR DESCRIPTION
## Summary

Documents and tests the product-facing smoke command now that AgentPlane exposes `sp-run smoke`.

The command is still pure facade delegation:

```bash
prophet governed-runner smoke --output-dir ./.socioprophet/smoke/governed-runner
```

Delegates to:

```bash
sp-run smoke --output-dir ./.socioprophet/smoke/governed-runner
```

## Adds

- README examples for `sp-run smoke` and `prophet governed-runner smoke`
- `tests/test_governed_runner_smoke_facade.py`

## Boundary

No governed-runner implementation moves into `prophet-cli`. This only documents and tests the facade path after AgentPlane added the actual `sp-run smoke` command.

## Validation

```bash
pytest -q
```