### PR TITLE
Document and test governed-runner inspection facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ prophet agentplane dossier ./.socioprophet/runs/governed-run-alpha-001
 prophet agentplane validate-dossier ./run-dossier.json
 prophet governed-runner doctor
 prophet governed-runner smoke --output-dir ./.socioprophet/smoke/governed-runner
+prophet governed-runner list --runs-root ./.socioprophet/smoke/governed-runner
+prophet governed-runner status ./.socioprophet/smoke/governed-runner/run
+prophet governed-runner inspect ./.socioprophet/smoke/governed-runner/run
 prophet governed-runner preflight ./governed-run-contract.json
 prophet governed-runner admit ./governed-run-contract.json --preflight ./preflight-receipt.json --authority-state ./agent-authority-current-state.json --projected-cost-usd 0.25
 prophet governed-runner dossier ./.socioprophet/runs/governed-run-alpha-001
@@ -68,9 +71,11 @@ For AgentPlane governed-runner commands, install or expose the AgentPlane-owned 
 python3 -m pip install -e /path/to/agentplane
 sp-run doctor
 sp-run smoke --output-dir ./.socioprophet/smoke/governed-runner
+sp-run list --runs-root ./.socioprophet/smoke/governed-runner
 prophet agentplane doctor
 prophet governed-runner doctor
 prophet governed-runner smoke --output-dir ./.socioprophet/smoke/governed-runner
+prophet governed-runner list --runs-root ./.socioprophet/smoke/governed-runner
 ```
 
 ## Boundary

--- a/tests/test_governed_runner_inspection_facade.py
+++ b/tests/test_governed_runner_inspection_facade.py
@@ -1,0 +1,92 @@
+"""Tests for Prophet governed-runner inspection facade commands."""
+
+from __future__ import annotations
+
+import subprocess
+
+from prophet_cli.cli import main
+
+
+class Completed:
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+
+def test_governed_runner_list_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main([
+        "governed-runner",
+        "list",
+        "--runs-root",
+        ".socioprophet/smoke/governed-runner",
+    ])
+
+    assert rc == 0
+    assert calls == [[
+        "/usr/bin/sp-run",
+        "list",
+        "--runs-root",
+        ".socioprophet/smoke/governed-runner",
+    ]]
+
+
+def test_governed_runner_status_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main([
+        "governed-runner",
+        "status",
+        ".socioprophet/smoke/governed-runner/run",
+    ])
+
+    assert rc == 0
+    assert calls == [[
+        "/usr/bin/sp-run",
+        "status",
+        ".socioprophet/smoke/governed-runner/run",
+    ]]
+
+
+def test_governed_runner_inspect_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main([
+        "governed-runner",
+        "inspect",
+        ".socioprophet/smoke/governed-runner/run",
+    ])
+
+    assert rc == 0
+    assert calls == [[
+        "/usr/bin/sp-run",
+        "inspect",
+        ".socioprophet/smoke/governed-runner/run",
+    ]]


### PR DESCRIPTION
## Summary

Documents and tests the product-facing governed-runner inspection commands now exposed by AgentPlane through `sp-run`.

These remain pure facade delegations:

```bash
prophet governed-runner list --runs-root ./.socioprophet/smoke/governed-runner
prophet governed-runner status ./.socioprophet/smoke/governed-runner/run
prophet governed-runner inspect ./.socioprophet/smoke/governed-runner/run
```

Delegates to:

```bash
sp-run list --runs-root ./.socioprophet/smoke/governed-runner
sp-run status ./.socioprophet/smoke/governed-runner/run
sp-run inspect ./.socioprophet/smoke/governed-runner/run
```

## Adds

- README examples for run-store inspection commands
- `tests/test_governed_runner_inspection_facade.py`

## Boundary

No governed-runner implementation moves into `prophet-cli`. This only documents and tests the facade path after AgentPlane added the actual `sp-run list/status/inspect` commands.

## Validation

```bash
pytest -q
```