### PR TITLE
Document and test governed-runner tool facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ prophet governed-runner smoke --output-dir ./.socioprophet/smoke/governed-runner
 prophet governed-runner list --runs-root ./.socioprophet/smoke/governed-runner
 prophet governed-runner status ./.socioprophet/smoke/governed-runner/run
 prophet governed-runner inspect ./.socioprophet/smoke/governed-runner/run
+prophet governed-runner tool list-tools
+prophet governed-runner tool call governed_runner.doctor --args-json '{}'
+prophet governed-runner tool call governed_runner.smoke --args-json '{"output_dir":".socioprophet/smoke/governed-runner"}'
 prophet governed-runner preflight ./governed-run-contract.json
 prophet governed-runner admit ./governed-run-contract.json --preflight ./preflight-receipt.json --authority-state ./agent-authority-current-state.json --projected-cost-usd 0.25
 prophet governed-runner dossier ./.socioprophet/runs/governed-run-alpha-001
@@ -72,10 +75,12 @@ python3 -m pip install -e /path/to/agentplane
 sp-run doctor
 sp-run smoke --output-dir ./.socioprophet/smoke/governed-runner
 sp-run list --runs-root ./.socioprophet/smoke/governed-runner
+sp-run tool list-tools
 prophet agentplane doctor
 prophet governed-runner doctor
 prophet governed-runner smoke --output-dir ./.socioprophet/smoke/governed-runner
 prophet governed-runner list --runs-root ./.socioprophet/smoke/governed-runner
+prophet governed-runner tool list-tools
 ```
 
 ## Boundary

--- a/tests/test_governed_runner_tool_facade.py
+++ b/tests/test_governed_runner_tool_facade.py
@@ -1,0 +1,62 @@
+"""Tests for Prophet governed-runner tool facade commands."""
+
+from __future__ import annotations
+
+import subprocess
+
+from prophet_cli.cli import main
+
+
+class Completed:
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+
+def test_governed_runner_tool_list_tools_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main(["governed-runner", "tool", "list-tools"])
+
+    assert rc == 0
+    assert calls == [["/usr/bin/sp-run", "tool", "list-tools"]]
+
+
+def test_governed_runner_tool_call_delegates_to_sp_run(monkeypatch):
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr("shutil.which", lambda binary: f"/usr/bin/{binary}")
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        assert check is False
+        return Completed(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc = main([
+        "governed-runner",
+        "tool",
+        "call",
+        "governed_runner.doctor",
+        "--args-json",
+        "{}",
+    ])
+
+    assert rc == 0
+    assert calls == [[
+        "/usr/bin/sp-run",
+        "tool",
+        "call",
+        "governed_runner.doctor",
+        "--args-json",
+        "{}",
+    ]]


### PR DESCRIPTION
## Summary

Documents and tests the product-facing governed-runner tool adapter path now exposed by AgentPlane through `sp-run tool ...`.

These remain pure facade delegations:

```bash
prophet governed-runner tool list-tools
prophet governed-runner tool call governed_runner.doctor --args-json '{}'
```

Delegates to:

```bash
sp-run tool list-tools
sp-run tool call governed_runner.doctor --args-json '{}'
```

## Adds

- README examples for `prophet governed-runner tool ...`
- `tests/test_governed_runner_tool_facade.py`

## Boundary

No governed-runner implementation moves into `prophet-cli`. This only documents and tests the facade path after AgentPlane added the actual `sp-run tool ...` delegate path.

## Validation

```bash
pytest -q
```