### PR TITLE
ci: replay K8s scheduling sample check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,13 @@ jobs:
           (
             cd socioprophet-standards-knowledge
             python3 k8s/tools/check_scheduling.py --manifest fixtures/semantic-core/k8s/valid-kubeedge-toleration.yaml --json
+            set +e
+            python3 k8s/tools/check_scheduling.py --manifest fixtures/semantic-core/k8s/invalid-kubeedge-missing-toleration.yaml --json
+            code=$?
+            set -e
+            if [ "$code" -eq 0 ]; then
+              exit 1
+            fi
           )
 
   k8s-policy-samples:


### PR DESCRIPTION
## Summary

Current-main replay of `prophet-cli#42`.

Adds explicit CI coverage for the standards-side K8s scheduling sample pair.

## Replays from

- Supersedes stale PR: `SocioProphet/prophet-cli#42`

## Change

Extends the `k8s-shapecheck` workflow job to run both the valid KubeEdge toleration sample and the missing-toleration sample from the standards repository.

## Boundary

CI-only. No command behavior changes.