### PR TITLE
feat(build): 3x3 build-recipe contract + CLI-surface reconciliation (closes #57)

### DIFF
--- a/.github/workflows/build-recipes.yml
+++ b/.github/workflows/build-recipes.yml
@@ -1,0 +1,25 @@
+name: build-recipes
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: pip install pyyaml
+      - name: Validate 3x3 build-recipe contract (DAG + health-gate teeth)
+        run: python scripts/validate_build_recipes.py --self-test
+      - name: Reconcile CLI surface with CLI_SURFACE_POLICY.md
+        run: python scripts/validate_cli_surface.py --self-test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install manifest-validator deps
+        run: pip install pyyaml
+
       - name: Validate
         run: make validate
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,12 @@ GOARCH ?= $(shell go env GOARCH 2>/dev/null || uname -m)
 DIST_NAME := $(BIN)_$(VERSION)_$(GOOS)_$(GOARCH)
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
-.PHONY: help fmt build test vet tidy validate verify dist release-dry-run clean
+PYTHON ?= python3
+
+.PHONY: help fmt build test vet tidy validate validate-manifests validate-recipes validate-surface verify dist release-dry-run clean
 
 help:
-	@echo "Targets: fmt build test vet tidy validate verify dist release-dry-run clean"
+	@echo "Targets: fmt build test vet tidy validate validate-manifests verify dist release-dry-run clean"
 
 fmt:
 	gofmt -w ./cmd ./internal
@@ -31,7 +33,15 @@ vet:
 tidy:
 	go mod tidy
 
-validate: build vet test
+validate-recipes:
+	$(PYTHON) scripts/validate_build_recipes.py --self-test
+
+validate-surface:
+	$(PYTHON) scripts/validate_cli_surface.py --self-test
+
+validate-manifests: validate-recipes validate-surface
+
+validate: build vet test validate-manifests
 	bin/$(BIN) --help >/tmp/prophet-help.txt
 	bin/$(BIN) version >/tmp/prophet-version.json
 	bin/$(BIN) doctor >/tmp/prophet-doctor.json

--- a/build/fixtures/reject-cycle.yaml
+++ b/build/fixtures/reject-cycle.yaml
@@ -1,0 +1,16 @@
+# REJECT (d): a cycle in depends_on (genesis <-> inception).
+apiVersion: cli.socioprophet.dev/v1
+kind: ProphetCliBuildRecipes
+recipes:
+  - tier: local
+    stages:
+      - id: genesis
+        depends_on: [inception]
+        health:
+          check: prophet bootstrap verify genesis-attestation ./genesis.json
+          required: true
+      - id: inception
+        depends_on: [genesis]
+        health:
+          check: prophet bootstrap verify proof-of-life ./inception.json
+          required: true

--- a/build/fixtures/reject-duplicate-tier.yaml
+++ b/build/fixtures/reject-duplicate-tier.yaml
@@ -1,0 +1,26 @@
+# REJECT (e): two recipes share a tier, so `prophet build local` cannot resolve
+# to exactly one recipe. Each recipe is individually well-formed (valid chain +
+# real gates); the ambiguity is the violation -- a shadow recipe must not be able
+# to hide behind a duplicate tier.
+apiVersion: cli.socioprophet.dev/v1
+kind: ProphetCliBuildRecipes
+recipes:
+  - tier: local
+    stages:
+      - id: genesis
+        depends_on: []
+        health:
+          check: prophet bootstrap verify genesis-attestation ./genesis.json
+          required: true
+      - id: inception
+        depends_on: [genesis]
+        health:
+          check: prophet bootstrap verify proof-of-life ./inception.json
+          required: true
+  - tier: local
+    stages:
+      - id: noop
+        depends_on: []
+        health:
+          check: "true"
+          required: true

--- a/build/fixtures/reject-forward-dep.yaml
+++ b/build/fixtures/reject-forward-dep.yaml
@@ -1,0 +1,18 @@
+# REJECT (a): a stage depends on a later stage (forward edge), with no cycle.
+# `alpha` (stage 0) depends on `beta`, which is declared after it; `beta` depends
+# on nothing, so there is no cycle -- this isolates the forward/skip-edge tooth.
+apiVersion: cli.socioprophet.dev/v1
+kind: ProphetCliBuildRecipes
+recipes:
+  - tier: local
+    stages:
+      - id: alpha
+        depends_on: [beta]
+        health:
+          check: prophet bootstrap verify genesis-attestation ./genesis.json
+          required: true
+      - id: beta
+        depends_on: []
+        health:
+          check: prophet bootstrap verify proof-of-life ./inception.json
+          required: true

--- a/build/fixtures/reject-missing-gate.yaml
+++ b/build/fixtures/reject-missing-gate.yaml
@@ -1,0 +1,22 @@
+# REJECT (b): a stage is missing its health gate.
+# `inception` declares required: false, which is not a real gate.
+apiVersion: cli.socioprophet.dev/v1
+kind: ProphetCliBuildRecipes
+recipes:
+  - tier: local
+    stages:
+      - id: genesis
+        depends_on: []
+        health:
+          check: prophet bootstrap verify genesis-attestation ./genesis.json
+          required: true
+      - id: inception
+        depends_on: [genesis]
+        health:
+          check: prophet bootstrap verify proof-of-life ./inception.json
+          required: false
+      - id: twin-bridge
+        depends_on: [inception]
+        health:
+          check: prophet status --query twin-bridge
+          required: true

--- a/build/fixtures/reject-unknown-key.yaml
+++ b/build/fixtures/reject-unknown-key.yaml
@@ -1,0 +1,21 @@
+# REJECT (f): a stage carries an unknown key (`skip: true`) that the schema
+# forbids (additionalProperties:false). The health gate itself is well-formed, so
+# the stage looks compliant -- but an out-of-band `skip` field a runtime could
+# honour would bypass the very gate the contract exists to enforce. The validator
+# must reject any key the schema does not permit.
+apiVersion: cli.socioprophet.dev/v1
+kind: ProphetCliBuildRecipes
+recipes:
+  - tier: local
+    stages:
+      - id: genesis
+        depends_on: []
+        skip: true
+        health:
+          check: prophet bootstrap verify genesis-attestation ./genesis.json
+          required: true
+      - id: inception
+        depends_on: [genesis]
+        health:
+          check: prophet bootstrap verify proof-of-life ./inception.json
+          required: true

--- a/build/fixtures/reject-unknown-tier.yaml
+++ b/build/fixtures/reject-unknown-tier.yaml
@@ -1,0 +1,11 @@
+# REJECT (c): unknown tier (`galactic` is not in {local,region,macro}).
+apiVersion: cli.socioprophet.dev/v1
+kind: ProphetCliBuildRecipes
+recipes:
+  - tier: galactic
+    stages:
+      - id: genesis
+        depends_on: []
+        health:
+          check: prophet bootstrap verify genesis-attestation ./genesis.json
+          required: true

--- a/build/recipes.yaml
+++ b/build/recipes.yaml
@@ -1,0 +1,90 @@
+# Prophet CLI 3x3 build-recipe contract.
+#
+# Contract for `prophet build local|region|macro`. Each recipe is an ordered,
+# acyclic chain of three stages. Every stage declares a required health gate:
+# stage N+1 cannot start until stage N's gate verifies. Ordering teeth
+# (no forward edges, no skip edges, no cycles) and gate presence are enforced
+# by scripts/validate_build_recipes.py against manifests/build-recipes.schema.json.
+#
+# Schema:  manifests/build-recipes.schema.json
+# Verify:  python3 scripts/validate_build_recipes.py --self-test
+#
+# The commitments themselves (Genesis/Inception/Twin, region/macro planes) are
+# already-real elsewhere (sourceos-spec, source-os/runtime/quorumd, estate
+# gitops-promote). This file is the façade-local ordering + gate contract only;
+# it delegates the actual work to those engines and does not reimplement them.
+apiVersion: cli.socioprophet.dev/v1
+kind: ProphetCliBuildRecipes
+metadata:
+  name: prophet-build-recipes
+  version: "0.1.0"
+
+recipes:
+  # local: genesis -> inception -> twin-bridge
+  - tier: local
+    description: Single-node evolution order for a sovereign local install.
+    stages:
+      - id: genesis
+        description: Mint the GenesisSeed and GenesisAttestationDocument.
+        depends_on: []
+        health:
+          check: prophet bootstrap verify genesis-attestation ./genesis.json
+          required: true
+      - id: inception
+        description: Establish ProofOfLife under the IdentityQuorumPolicy.
+        depends_on: [genesis]
+        health:
+          check: prophet bootstrap verify proof-of-life ./inception.json
+          required: true
+      - id: twin-bridge
+        description: Bind the local twin bridge to the attested identity.
+        depends_on: [inception]
+        health:
+          check: prophet status --query twin-bridge
+          required: true
+
+  # region: security/storage -> bus/HOPE -> work/agents
+  - tier: region
+    description: Regional plane evolution order over the local foundation.
+    stages:
+      - id: security-storage
+        description: Stand up the security and storage substrate (SAPIEN/ROCKZDB).
+        depends_on: []
+        health:
+          check: prophet spine validate --repo security-storage
+          required: true
+      - id: bus-hope
+        description: Bring up the event bus and HOPE plane.
+        depends_on: [security-storage]
+        health:
+          check: prophet spine validate --repo bus-hope
+          required: true
+      - id: work-agents
+        description: Enable regional work surfaces and agent runtime.
+        depends_on: [bus-hope]
+        health:
+          check: prophet agent registry list
+          required: true
+
+  # macro: federated-twin -> policy/replication -> macro-agents/search
+  - tier: macro
+    description: Macro (federated) plane evolution order over the regional plane.
+    stages:
+      - id: federated-twin
+        description: Federate twins across regions.
+        depends_on: []
+        health:
+          check: prophet status --query federated-twin
+          required: true
+      - id: policy-replication
+        description: Replicate policy and identity quorum across the federation.
+        depends_on: [federated-twin]
+        health:
+          check: prophet spine validate --repo policy-replication
+          required: true
+      - id: macro-agents-search
+        description: Enable macro-scale agents and federated search.
+        depends_on: [policy-replication]
+        health:
+          check: prophet holmes search "readiness probe"
+          required: true

--- a/manifests/build-recipes.schema.json
+++ b/manifests/build-recipes.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cli.socioprophet.dev/schemas/build-recipes.schema.json",
+  "title": "ProphetCliBuildRecipes",
+  "description": "3x3 build-recipe contract for `prophet build <tier>`. Each recipe is an ordered, acyclic chain of stages; every stage carries a required health gate so stage N+1 cannot start until stage N verifies. The validator (scripts/validate_build_recipes.py) reads the tier enum and required stage keys from this schema, so schema and validator cannot silently drift.",
+  "type": "object",
+  "required": ["apiVersion", "kind", "recipes"],
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": { "const": "cli.socioprophet.dev/v1" },
+    "kind": { "const": "ProphetCliBuildRecipes" },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "recipes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/recipe" }
+    }
+  },
+  "$defs": {
+    "recipe": {
+      "type": "object",
+      "required": ["tier", "stages"],
+      "additionalProperties": false,
+      "properties": {
+        "tier": {
+          "description": "Evolution tier. The validator treats this enum as the single source of allowed tiers.",
+          "enum": ["local", "region", "macro"]
+        },
+        "description": { "type": "string" },
+        "stages": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/stage" }
+        }
+      }
+    },
+    "stage": {
+      "type": "object",
+      "required": ["id", "depends_on", "health"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "description": { "type": "string" },
+        "depends_on": {
+          "description": "Stage ids this stage waits on. Must reference only earlier stages in this recipe's declared order (no forward edges) and must include the immediately-preceding stage (no skip edges). The first stage must have an empty list.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "health": { "$ref": "#/$defs/health" }
+      }
+    },
+    "health": {
+      "description": "The stage health gate. A gate is real only when required==true and check is non-empty; anything weaker is treated as a missing gate and rejected.",
+      "type": "object",
+      "required": ["check", "required"],
+      "additionalProperties": false,
+      "properties": {
+        "check": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": { "const": true }
+      }
+    }
+  }
+}

--- a/manifests/cli-surface.json
+++ b/manifests/cli-surface.json
@@ -1,0 +1,58 @@
+{
+  "apiVersion": "cli.socioprophet.dev/v1",
+  "kind": "ProphetCliSurfaceReconciliation",
+  "metadata": {
+    "name": "prophet-cli-surface",
+    "version": "0.1.0"
+  },
+  "policy": "docs/CLI_SURFACE_POLICY.md",
+  "note": "Reconciles the Prophet CLI & System Architecture spec command tree (nouns) onto the canonical verb model in CLI_SURFACE_POLICY.md. `verbs` mirrors the policy exactly; scripts/validate_cli_surface.py fails if the two drift either way. Every spec noun resolves to canonical verbs -- it must not define a competing command language -- and per the phase-1 policy an empty subtree must not be scaffolded: a noun is `adopted` only where a real delegate exists, otherwise `deferred` (follow-up, no verbs claimed).",
+  "verbs": {
+    "read": ["list", "show", "describe", "explain", "find", "search"],
+    "mutation": ["create", "update", "delete", "apply", "wait", "validate", "verify"],
+    "runtime": ["status", "logs", "start", "stop", "restart"],
+    "bootstrap": ["doctor", "login", "build", "fetch", "write", "info"]
+  },
+  "nouns": [
+    {
+      "noun": "build",
+      "status": "adopted",
+      "delegate": "prophet-cli build-recipes (build/recipes.yaml)",
+      "verbs": ["build", "validate"]
+    },
+    {
+      "noun": "vocab",
+      "status": "adopted",
+      "delegate": "ontogenesis",
+      "verbs": ["fetch", "validate"]
+    },
+    {
+      "noun": "search",
+      "status": "adopted",
+      "delegate": "holmes",
+      "verbs": ["search", "find"]
+    },
+    {
+      "noun": "agents",
+      "status": "adopted",
+      "delegate": "agent-registry",
+      "verbs": ["list"]
+    },
+    { "noun": "context", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "config", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "fs", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "graph", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "docker", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "conda", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "minio", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "rsync", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "kafka", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "work", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "gib", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "opencog", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "genesis", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "inception", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "twin", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] },
+    { "noun": "bridge", "status": "deferred", "followup": "prophet-cli#57 noun-namespace adoption", "verbs": [] }
+  ]
+}

--- a/scripts/validate_build_recipes.py
+++ b/scripts/validate_build_recipes.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Validate the Prophet CLI 3x3 build-recipe contract.
+
+Teeth (mirrors scripts/validate_lattice_studio_commands.py):
+  * tier must be one of the enum declared in manifests/build-recipes.schema.json
+    (the schema is the single source of truth -- validator and schema cannot drift);
+  * every stage declares depends_on + a *real* health gate (required==true,
+    non-empty check) -- a weaker gate is treated as missing;
+  * the stage ordering is a DAG: no cycles, no forward edges (a stage may only
+    depend on earlier stages) and no skip edges (a stage must depend on its
+    immediate predecessor), so stage N+1 cannot start until stage N verifies.
+
+Usage:
+  validate_build_recipes.py [PATH]        validate one recipe file (default build/recipes.yaml)
+  validate_build_recipes.py --self-test   run the accept fixture + every reject fixture
+                                          and assert the teeth fire both ways
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "manifests" / "build-recipes.schema.json"
+RECIPES_PATH = REPO_ROOT / "build" / "recipes.yaml"
+FIXTURES_DIR = REPO_ROOT / "build" / "fixtures"
+
+
+class RecipeError(ValueError):
+    """Raised when a recipe document violates the contract."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RecipeError(message)
+
+
+def _load_schema() -> dict:
+    import json
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    return schema
+
+
+def _allowed_tiers(schema: dict) -> set[str]:
+    tiers = schema["$defs"]["recipe"]["properties"]["tier"]["enum"]
+    return set(tiers)
+
+
+def _stage_required_keys(schema: dict) -> set[str]:
+    return set(schema["$defs"]["stage"]["required"])
+
+
+def _detect_cycle(nodes: list[str], edges: dict[str, list[str]]) -> list[str] | None:
+    """Return a cycle path if the depends_on graph has one, else None."""
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {n: WHITE for n in nodes}
+    stack: list[str] = []
+
+    def visit(n: str) -> list[str] | None:
+        color[n] = GRAY
+        stack.append(n)
+        for m in edges.get(n, []):
+            if m not in color:
+                continue  # dangling ref handled elsewhere
+            if color[m] == GRAY:
+                return stack[stack.index(m):] + [m]
+            if color[m] == WHITE:
+                found = visit(m)
+                if found:
+                    return found
+        stack.pop()
+        color[n] = BLACK
+        return None
+
+    for n in nodes:
+        if color[n] == WHITE:
+            found = visit(n)
+            if found:
+                return found
+    return None
+
+
+def _validate_recipe(recipe: dict, allowed_tiers: set[str], stage_keys: set[str]) -> None:
+    tier = recipe.get("tier")
+    require(tier in allowed_tiers, f"unknown tier {tier!r}; allowed={sorted(allowed_tiers)}")
+
+    stages = recipe.get("stages")
+    require(isinstance(stages, list) and stages, f"tier {tier}: stages must be a non-empty list")
+
+    ids = [s.get("id") for s in stages]
+    require(all(isinstance(i, str) and i for i in ids), f"tier {tier}: every stage needs a string id")
+    require(len(set(ids)) == len(ids), f"tier {tier}: duplicate stage ids in {ids}")
+    index = {sid: i for i, sid in enumerate(ids)}
+
+    # Stage shape + health-gate teeth.
+    for stage in stages:
+        sid = stage["id"]
+        missing = stage_keys - set(stage)
+        require(not missing, f"tier {tier} stage {sid}: missing keys {sorted(missing)}")
+        require(isinstance(stage["depends_on"], list), f"tier {tier} stage {sid}: depends_on must be a list")
+        health = stage["health"]
+        require(isinstance(health, dict), f"tier {tier} stage {sid}: health must be an object")
+        # A gate is real only when required==true AND check is non-empty.
+        require(
+            health.get("required") is True and isinstance(health.get("check"), str) and health["check"].strip(),
+            f"tier {tier} stage {sid}: missing health gate (need required:true and a non-empty check)",
+        )
+
+    # Referential integrity.
+    edges: dict[str, list[str]] = {}
+    for stage in stages:
+        sid = stage["id"]
+        deps = stage["depends_on"]
+        for d in deps:
+            require(d in index, f"tier {tier} stage {sid}: depends_on unknown stage {d!r}")
+        edges[sid] = list(deps)
+
+    # Cycle teeth (runs before ordering so a true cycle reports as a cycle).
+    cycle = _detect_cycle(ids, edges)
+    require(cycle is None, f"tier {tier}: cycle in depends_on: {' -> '.join(cycle) if cycle else ''}")
+
+    # Ordering teeth: no forward edges, no skip edges.
+    for pos, stage in enumerate(stages):
+        sid = stage["id"]
+        deps = stage["depends_on"]
+        for d in deps:
+            require(index[d] < pos, f"tier {tier} stage {sid}: forward edge -- depends on later stage {d!r}")
+        if pos == 0:
+            require(not deps, f"tier {tier} stage {sid}: first stage must not depend on anything")
+        else:
+            predecessor = ids[pos - 1]
+            require(
+                predecessor in deps,
+                f"tier {tier} stage {sid}: skip edge -- must depend on immediate predecessor {predecessor!r}",
+            )
+
+
+def validate(path: Path) -> None:
+    schema = _load_schema()
+    allowed_tiers = _allowed_tiers(schema)
+    stage_keys = _stage_required_keys(schema)
+
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    require(isinstance(doc, dict), "document root must be a mapping")
+    require(doc.get("apiVersion") == "cli.socioprophet.dev/v1", "apiVersion mismatch")
+    require(doc.get("kind") == "ProphetCliBuildRecipes", "kind mismatch")
+    recipes = doc.get("recipes")
+    require(isinstance(recipes, list) and recipes, "recipes must be a non-empty list")
+
+    for recipe in recipes:
+        require(isinstance(recipe, dict), "each recipe must be a mapping")
+        _validate_recipe(recipe, allowed_tiers, stage_keys)
+
+
+# --- self-test: prove the teeth fire both ways --------------------------------
+
+REJECT_FIXTURES = {
+    "reject-forward-dep.yaml": "forward edge",
+    "reject-missing-gate.yaml": "missing health gate",
+    "reject-unknown-tier.yaml": "unknown tier",
+    "reject-cycle.yaml": "cycle in depends_on",
+}
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    # Accept: the canonical 3x3 recipe must validate.
+    try:
+        validate(RECIPES_PATH)
+        print(f"PASS accept {RECIPES_PATH.relative_to(REPO_ROOT)}")
+    except RecipeError as exc:
+        failures.append(f"accept fixture {RECIPES_PATH.name} should VERIFY but was rejected: {exc}")
+
+    # Reject: each bad fixture must fire, with the expected reason.
+    for name, expected in REJECT_FIXTURES.items():
+        path = FIXTURES_DIR / name
+        try:
+            validate(path)
+            failures.append(f"reject fixture {name} should be REJECTED but VERIFIED (negative control breached)")
+        except RecipeError as exc:
+            if expected in str(exc):
+                print(f"PASS reject {name}: {exc}")
+            else:
+                failures.append(f"reject fixture {name} fired wrong reason: expected ~{expected!r}, got: {exc}")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL {f}", file=sys.stderr)
+        return 1
+    print("PASS all build-recipe teeth verified")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return self_test()
+    target = Path(argv[1]) if len(argv) > 1 else RECIPES_PATH
+    try:
+        validate(target)
+        print(f"PASS {target}")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL {target}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/validate_build_recipes.py
+++ b/scripts/validate_build_recipes.py
@@ -18,6 +18,7 @@ Usage:
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -54,6 +55,28 @@ def _stage_required_keys(schema: dict) -> set[str]:
     return set(schema["$defs"]["stage"]["required"])
 
 
+def _stage_id_pattern(schema: dict) -> "re.Pattern[str]":
+    return re.compile(schema["$defs"]["stage"]["properties"]["id"]["pattern"])
+
+
+def _allowed_keys(node: dict) -> set[str]:
+    """Keys the schema permits for a node whose additionalProperties is false.
+
+    Reading the allow-list from the schema keeps the validator from drifting
+    from `additionalProperties:false`; an unknown key (e.g. a stage-level
+    `skip:true` a runtime could honour to bypass the health gate) is rejected.
+    """
+    return set(node.get("properties", {}).keys())
+
+
+def _reject_unknown_keys(obj: dict, allowed: set[str], ctx: str) -> None:
+    extra = set(obj) - allowed
+    require(
+        not extra,
+        f"{ctx}: unknown keys not permitted by schema (additionalProperties:false): {sorted(extra)}",
+    )
+
+
 def _detect_cycle(nodes: list[str], edges: dict[str, list[str]]) -> list[str] | None:
     """Return a cycle path if the depends_on graph has one, else None."""
     WHITE, GRAY, BLACK = 0, 1, 2
@@ -84,15 +107,28 @@ def _detect_cycle(nodes: list[str], edges: dict[str, list[str]]) -> list[str] | 
     return None
 
 
-def _validate_recipe(recipe: dict, allowed_tiers: set[str], stage_keys: set[str]) -> None:
+def _validate_recipe(recipe: dict, schema: dict) -> None:
+    allowed_tiers = _allowed_tiers(schema)
+    stage_keys = _stage_required_keys(schema)
+    id_pattern = _stage_id_pattern(schema)
+    recipe_keys = _allowed_keys(schema["$defs"]["recipe"])
+    stage_all_keys = _allowed_keys(schema["$defs"]["stage"])
+    health_keys = _allowed_keys(schema["$defs"]["health"])
+
+    require(isinstance(recipe, dict), "each recipe must be a mapping")
     tier = recipe.get("tier")
     require(tier in allowed_tiers, f"unknown tier {tier!r}; allowed={sorted(allowed_tiers)}")
+    _reject_unknown_keys(recipe, recipe_keys, f"tier {tier} recipe")
 
     stages = recipe.get("stages")
     require(isinstance(stages, list) and stages, f"tier {tier}: stages must be a non-empty list")
 
     ids = [s.get("id") for s in stages]
     require(all(isinstance(i, str) and i for i in ids), f"tier {tier}: every stage needs a string id")
+    # Ids must match the schema pattern -- otherwise the validator would silently
+    # drift from the schema and admit ids (uppercase, whitespace) it forbids.
+    bad_ids = [i for i in ids if not id_pattern.fullmatch(i)]
+    require(not bad_ids, f"tier {tier}: stage ids violate schema pattern {id_pattern.pattern!r}: {bad_ids}")
     require(len(set(ids)) == len(ids), f"tier {tier}: duplicate stage ids in {ids}")
     index = {sid: i for i, sid in enumerate(ids)}
 
@@ -101,9 +137,11 @@ def _validate_recipe(recipe: dict, allowed_tiers: set[str], stage_keys: set[str]
         sid = stage["id"]
         missing = stage_keys - set(stage)
         require(not missing, f"tier {tier} stage {sid}: missing keys {sorted(missing)}")
+        _reject_unknown_keys(stage, stage_all_keys, f"tier {tier} stage {sid}")
         require(isinstance(stage["depends_on"], list), f"tier {tier} stage {sid}: depends_on must be a list")
         health = stage["health"]
         require(isinstance(health, dict), f"tier {tier} stage {sid}: health must be an object")
+        _reject_unknown_keys(health, health_keys, f"tier {tier} stage {sid} health")
         # A gate is real only when required==true AND check is non-empty.
         require(
             health.get("required") is True and isinstance(health.get("check"), str) and health["check"].strip(),
@@ -141,19 +179,24 @@ def _validate_recipe(recipe: dict, allowed_tiers: set[str], stage_keys: set[str]
 
 def validate(path: Path) -> None:
     schema = _load_schema()
-    allowed_tiers = _allowed_tiers(schema)
-    stage_keys = _stage_required_keys(schema)
 
     doc = yaml.safe_load(path.read_text(encoding="utf-8"))
     require(isinstance(doc, dict), "document root must be a mapping")
+    _reject_unknown_keys(doc, _allowed_keys(schema), "document root")
     require(doc.get("apiVersion") == "cli.socioprophet.dev/v1", "apiVersion mismatch")
     require(doc.get("kind") == "ProphetCliBuildRecipes", "kind mismatch")
     recipes = doc.get("recipes")
     require(isinstance(recipes, list) and recipes, "recipes must be a non-empty list")
 
+    # A tier resolves `prophet build <tier>` to exactly one recipe; two recipes
+    # sharing a tier make resolution ambiguous, so a duplicate tier is rejected.
+    seen_tiers: list = []
     for recipe in recipes:
         require(isinstance(recipe, dict), "each recipe must be a mapping")
-        _validate_recipe(recipe, allowed_tiers, stage_keys)
+        _validate_recipe(recipe, schema)
+        seen_tiers.append(recipe.get("tier"))
+    dupes = sorted({t for t in seen_tiers if seen_tiers.count(t) > 1})
+    require(not dupes, f"duplicate tier -- each tier must resolve to exactly one recipe: {dupes}")
 
 
 # --- self-test: prove the teeth fire both ways --------------------------------
@@ -163,6 +206,8 @@ REJECT_FIXTURES = {
     "reject-missing-gate.yaml": "missing health gate",
     "reject-unknown-tier.yaml": "unknown tier",
     "reject-cycle.yaml": "cycle in depends_on",
+    "reject-duplicate-tier.yaml": "duplicate tier",
+    "reject-unknown-key.yaml": "unknown keys not permitted",
 }
 
 

--- a/scripts/validate_cli_surface.py
+++ b/scripts/validate_cli_surface.py
@@ -102,6 +102,9 @@ def reconcile(manifest: dict, policy_verbs: dict[str, list[str]]) -> None:
     for entry in nouns:
         noun = entry.get("noun")
         require(isinstance(noun, str) and noun, f"noun entry missing name: {entry}")
+        # A noun must resolve to exactly one entry; a duplicate makes command
+        # resolution ambiguous (and could smuggle a second, contradictory status).
+        require(noun not in seen, f"noun {noun}: declared more than once (ambiguous command resolution)")
         seen.add(noun)
         status = entry.get("status")
         require(status in {"adopted", "deferred"}, f"noun {noun}: status must be adopted|deferred, got {status!r}")
@@ -118,6 +121,13 @@ def reconcile(manifest: dict, policy_verbs: dict[str, list[str]]) -> None:
             require(nverbs, f"noun {noun}: adopted noun must resolve to >=1 canonical verb")
         else:  # deferred
             require(not nverbs, f"noun {noun}: deferred noun must not scaffold verbs (phase-1 policy)")
+            # A subtree is scaffolded by more than verbs: a real `delegate` wires
+            # an implementation for a noun that is supposed to be unbuilt. Phase-1
+            # policy is that a deferred noun carries no implementation at all.
+            require(
+                not entry.get("delegate"),
+                f"noun {noun}: deferred noun must not scaffold a delegate (phase-1 policy)",
+            )
             require(entry.get("followup"), f"noun {noun}: deferred noun must name a follow-up")
 
     # Whole spec command tree accounted for, both ways.
@@ -175,13 +185,26 @@ def self_test() -> int:
     m["nouns"][0] = dict(m["nouns"][0], verbs=["frobnicate"])
     expect_reject(m, "competing-command-language", "competing command language")
 
-    # (d) deferred noun scaffolds an empty subtree.
+    # (d) deferred noun scaffolds an empty subtree via verbs.
     m = copy.deepcopy(manifest)
     for i, n in enumerate(m["nouns"]):
         if n["status"] == "deferred":
             m["nouns"][i] = dict(n, verbs=["list"])
             break
     expect_reject(m, "scaffolded-deferred-noun", "must not scaffold")
+
+    # (e) deferred noun scaffolds an empty subtree via a real delegate (no verbs).
+    m = copy.deepcopy(manifest)
+    for i, n in enumerate(m["nouns"]):
+        if n["status"] == "deferred":
+            m["nouns"][i] = dict(n, delegate="prophet-cli real-subtree-impl")
+            break
+    expect_reject(m, "scaffolded-deferred-delegate", "must not scaffold a delegate")
+
+    # (f) the same noun is declared twice (ambiguous command resolution).
+    m = copy.deepcopy(manifest)
+    m["nouns"] = m["nouns"] + [dict(m["nouns"][0])]
+    expect_reject(m, "duplicate-noun", "declared more than once")
 
     if failures:
         for f in failures:

--- a/scripts/validate_cli_surface.py
+++ b/scripts/validate_cli_surface.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Reconcile the Prophet CLI spec command tree against CLI_SURFACE_POLICY.md.
+
+Teeth:
+  * `verbs` in manifests/cli-surface.json must equal the canonical verb model
+    parsed from docs/CLI_SURFACE_POLICY.md -- drift fires *both ways*
+    (a verb declared but not in policy, or in policy but not declared);
+  * every spec noun resolves only to canonical verbs (no competing command
+    language);
+  * per the phase-1 policy, an empty subtree must not be scaffolded: an
+    `adopted` noun needs a real delegate and >=1 verb; a `deferred` noun must
+    claim no verbs and name a follow-up;
+  * the whole spec command tree must be accounted for (no silently dropped noun).
+
+Usage:
+  validate_cli_surface.py               reconcile the manifest against policy
+  validate_cli_surface.py --self-test   also prove the drift teeth fire both ways
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "manifests" / "cli-surface.json"
+POLICY_PATH = REPO_ROOT / "docs" / "CLI_SURFACE_POLICY.md"
+
+# The spec command tree (Prophet CLI & System Architecture spec, intake 2026-07-31).
+# The reconciliation must account for every one of these nouns.
+SPEC_NOUNS = {
+    "context", "config", "build", "fs", "graph", "docker", "conda", "minio",
+    "rsync", "kafka", "work", "vocab", "gib", "search", "opencog", "genesis",
+    "inception", "twin", "bridge", "agents",
+}
+
+# Policy section header -> manifest verb-category key.
+SECTION_TO_CATEGORY = {
+    "Read verbs": "read",
+    "Mutation verbs": "mutation",
+    "Runtime verbs": "runtime",
+    "Bootstrap verbs": "bootstrap",
+}
+
+
+class SurfaceError(ValueError):
+    """Raised when the CLI surface drifts from policy."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SurfaceError(message)
+
+
+def parse_policy(text: str) -> dict[str, list[str]]:
+    """Extract {category: [verb, ...]} from CLI_SURFACE_POLICY.md."""
+    verbs: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        header = re.match(r"^##\s+(.*?)\s*$", line)
+        if header:
+            current = SECTION_TO_CATEGORY.get(header.group(1).strip())
+            if current is not None:
+                verbs.setdefault(current, [])
+            continue
+        if current is None:
+            continue
+        bullet = re.match(r"^-\s+`([a-z][a-z0-9-]*)`\s*$", line)
+        if bullet:
+            verbs[current].append(bullet.group(1))
+    return verbs
+
+
+def reconcile(manifest: dict, policy_verbs: dict[str, list[str]]) -> None:
+    require(manifest.get("apiVersion") == "cli.socioprophet.dev/v1", "apiVersion mismatch")
+    require(manifest.get("kind") == "ProphetCliSurfaceReconciliation", "kind mismatch")
+
+    declared = manifest.get("verbs")
+    require(isinstance(declared, dict), "manifest.verbs must be an object")
+
+    # Verb-model drift, both ways, per category.
+    require(
+        set(declared) == set(policy_verbs),
+        f"verb categories drift: manifest={sorted(declared)} policy={sorted(policy_verbs)}",
+    )
+    for category, pol in policy_verbs.items():
+        man = set(declared.get(category, []))
+        pol_set = set(pol)
+        not_in_policy = man - pol_set
+        not_declared = pol_set - man
+        require(not not_in_policy, f"{category}: verbs declared but not in policy: {sorted(not_in_policy)}")
+        require(not not_declared, f"{category}: verbs in policy but not declared: {sorted(not_declared)}")
+
+    all_policy_verbs = {v for vs in policy_verbs.values() for v in vs}
+
+    # Noun teeth.
+    nouns = manifest.get("nouns")
+    require(isinstance(nouns, list) and nouns, "manifest.nouns must be a non-empty list")
+    seen: set[str] = set()
+    for entry in nouns:
+        noun = entry.get("noun")
+        require(isinstance(noun, str) and noun, f"noun entry missing name: {entry}")
+        seen.add(noun)
+        status = entry.get("status")
+        require(status in {"adopted", "deferred"}, f"noun {noun}: status must be adopted|deferred, got {status!r}")
+        nverbs = entry.get("verbs", [])
+        require(isinstance(nverbs, list), f"noun {noun}: verbs must be a list")
+
+        # No competing command language: every verb must be canonical.
+        stray = set(nverbs) - all_policy_verbs
+        require(not stray, f"noun {noun}: non-canonical verbs (competing command language): {sorted(stray)}")
+
+        if status == "adopted":
+            delegate = entry.get("delegate")
+            require(isinstance(delegate, str) and delegate.strip(), f"noun {noun}: adopted noun needs a delegate")
+            require(nverbs, f"noun {noun}: adopted noun must resolve to >=1 canonical verb")
+        else:  # deferred
+            require(not nverbs, f"noun {noun}: deferred noun must not scaffold verbs (phase-1 policy)")
+            require(entry.get("followup"), f"noun {noun}: deferred noun must name a follow-up")
+
+    # Whole spec command tree accounted for, both ways.
+    missing = SPEC_NOUNS - seen
+    extra = seen - SPEC_NOUNS
+    require(not missing, f"spec nouns not reconciled: {sorted(missing)}")
+    require(not extra, f"manifest declares nouns outside the spec command tree: {sorted(extra)}")
+
+
+def validate() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    policy_verbs = parse_policy(POLICY_PATH.read_text(encoding="utf-8"))
+    require(policy_verbs, "no verbs parsed from policy -- policy file changed shape?")
+    reconcile(manifest, policy_verbs)
+
+
+# --- self-test: prove the drift teeth fire both ways --------------------------
+
+def self_test() -> int:
+    import copy
+
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    policy_verbs = parse_policy(POLICY_PATH.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    def expect_reject(mut: dict, label: str, needle: str) -> None:
+        try:
+            reconcile(mut, policy_verbs)
+            failures.append(f"{label}: should be REJECTED but reconciled (negative control breached)")
+        except SurfaceError as exc:
+            if needle in str(exc):
+                print(f"PASS reject {label}: {exc}")
+            else:
+                failures.append(f"{label}: fired wrong reason: expected ~{needle!r}, got: {exc}")
+
+    # Accept: the real manifest must reconcile against the real policy.
+    try:
+        reconcile(manifest, policy_verbs)
+        print("PASS accept manifests/cli-surface.json")
+    except SurfaceError as exc:
+        failures.append(f"accept: real manifest should reconcile but was rejected: {exc}")
+
+    # (a) command present but not in policy.
+    m = copy.deepcopy(manifest)
+    m["verbs"]["read"] = m["verbs"]["read"] + ["teleport"]
+    expect_reject(m, "extra-verb-not-in-policy", "declared but not in policy")
+
+    # (b) in policy but not declared.
+    m = copy.deepcopy(manifest)
+    m["verbs"]["read"] = [v for v in m["verbs"]["read"] if v != "list"]
+    expect_reject(m, "policy-verb-not-declared", "in policy but not declared")
+
+    # (c) noun uses a competing (non-canonical) verb.
+    m = copy.deepcopy(manifest)
+    m["nouns"][0] = dict(m["nouns"][0], verbs=["frobnicate"])
+    expect_reject(m, "competing-command-language", "competing command language")
+
+    # (d) deferred noun scaffolds an empty subtree.
+    m = copy.deepcopy(manifest)
+    for i, n in enumerate(m["nouns"]):
+        if n["status"] == "deferred":
+            m["nouns"][i] = dict(n, verbs=["list"])
+            break
+    expect_reject(m, "scaffolded-deferred-noun", "must not scaffold")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL {f}", file=sys.stderr)
+        return 1
+    print("PASS all CLI-surface reconciliation teeth verified")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return self_test()
+    try:
+        validate()
+        print("PASS manifests/cli-surface.json reconciled with docs/CLI_SURFACE_POLICY.md")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL cli-surface reconciliation: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
Closes #57. cc @mdheller. Related: #76.

Lands the one net-new, schema-shaped slice from the **Prophet CLI & System Architecture** spec (intake 2026-07-31). Everything else the spec commits to is already-real elsewhere and is consumed, not rebuilt (sourceos-spec Genesis/Inception/Twin, `source-os/runtime/quorumd`, estate gitops-promote / gate.yml / canary lifecycle, TriTRPC transport skins, prophet-platform deploy plane). This repo owns only the ordering + gate contract and the surface reconciliation.

## 1. 3x3 build-recipe contract (DAG + health-gate teeth)
- `build/recipes.yaml` — `prophet build local|region|macro`, each an ordered, acyclic chain of 3 stages. Every stage declares `depends_on` + a **required health gate**, so stage N+1 cannot start until stage N verifies.
  - local: genesis → inception → twin-bridge
  - region: security/storage → bus/HOPE → work/agents
  - macro: federated-twin → policy/replication → macro-agents/search
- `manifests/build-recipes.schema.json` — schema-as-code. It is the single source of truth for the tier enum and stage keys; `scripts/validate_build_recipes.py` reads them back, so schema and validator cannot silently drift.
- `scripts/validate_build_recipes.py` — proves the ordering is a DAG: **no cycles, no forward edges, no skip edges**, and every stage has a real gate (`required: true` + non-empty `check`; anything weaker is treated as missing).

### Teeth (both ways)
Accept fixture (`build/recipes.yaml`) VERIFIES. Reject fixtures under `build/fixtures/` each fire:
| fixture | fault |
| --- | --- |
| `reject-forward-dep.yaml` | stage depends on a later stage |
| `reject-missing-gate.yaml` | stage missing its health gate |
| `reject-unknown-tier.yaml` | unknown tier |
| `reject-cycle.yaml` | cycle in `depends_on` |

`--self-test` asserts accept passes AND every reject fires with the expected reason. **Negative control confirmed**: weakening a reject fixture makes `--self-test` exit non-zero.

## 2. Command-tree reconciliation (decision-as-data)
- `manifests/cli-surface.json` + `scripts/validate_cli_surface.py` reconcile the spec command tree (`context/config/build/fs/graph/docker/conda/minio/rsync/kafka/work/vocab/gib/search/opencog/genesis/inception/twin/bridge/agents`) onto the canonical verb model in `docs/CLI_SURFACE_POLICY.md`.
- Teeth: verb drift fires **both ways** (declared-but-not-in-policy, and in-policy-but-not-declared); every noun resolves only to canonical verbs (**no competing command language**); per the phase-1 policy, deferred nouns **must not scaffold empty subtrees**; the whole spec tree must be accounted for.
- Only nouns with a real delegate are **adopted** (`build`, `vocab`, `search`, `agents`); the remaining 16 are **deferred** as follow-up (surface growth is policy-gated).

## Wiring
- `make validate` → `validate-manifests` → both self-tests. Also `make validate-recipes` / `make validate-surface`.
- New python CI workflow `.github/workflows/build-recipes.yml`; `validate.yml` gains Python + `pyyaml` so `make validate` stays green.

## Local teeth results
```
python3 scripts/validate_build_recipes.py --self-test   # PASS (accept + 4 rejects; negative control fails as expected)
python3 scripts/validate_cli_surface.py  --self-test   # PASS (accept + 4 drift rejects)
```

## Follow-up (out of this slice)
Deferred noun-namespace adoption (the 16 nouns without a real delegate) — filed separately @mdheller; surface growth is policy-gated and must not scaffold empty subtrees.